### PR TITLE
interallでの演算子の入れ替えに関するバグ

### DIFF
--- a/src/StdFace_ModelUtil.c
+++ b/src/StdFace_ModelUtil.c
@@ -61,6 +61,7 @@ void StdFace_trans(
   int jspin//!<[in] @f$\sigma'@f$ for @f$c_{j \sigma'}@f$
 )
 {
+  if (cabs(trans0) < 1.0e-12) return;
   StdI->trans[StdI->ntrans] = trans0;
   StdI->transindx[StdI->ntrans][0] = isite;
   StdI->transindx[StdI->ntrans][1] = ispin;
@@ -209,6 +210,7 @@ void StdFace_intr(
   int spin4//!<[in] @f$sigma1_2@f$ for @f$c_{i_2 \sigma_2}@f$
 )
 {
+  if (cabs(intr0) < 1.0e-12) return;
   StdI->intr[StdI->nintr] = intr0;
   StdI->intrindx[StdI->nintr][0] = site1; StdI->intrindx[StdI->nintr][1] = spin1;
   StdI->intrindx[StdI->nintr][2] = site2; StdI->intrindx[StdI->nintr][3] = spin2;

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -2133,10 +2133,13 @@ static void PrintInteractions(struct StdIntList *StdI)
   /*
    InterAll
   */
+  //
+  // Merge equivalent terms
+  //
   for (jintr = 0; jintr < StdI->nintr; jintr++) {
     for (kintr = jintr + 1; kintr < StdI->nintr; kintr++) {
       if (
-        (StdI->intrindx[jintr][0] == StdI->intrindx[kintr][0]
+        (    StdI->intrindx[jintr][0] == StdI->intrindx[kintr][0]
           && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][1]
           && StdI->intrindx[jintr][2] == StdI->intrindx[kintr][2]
           && StdI->intrindx[jintr][3] == StdI->intrindx[kintr][3]
@@ -2145,46 +2148,64 @@ static void PrintInteractions(struct StdIntList *StdI)
           && StdI->intrindx[jintr][6] == StdI->intrindx[kintr][6]
           && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][7])
         ||
-        (StdI->intrindx[jintr][0] == StdI->intrindx[kintr][4]
+        (    StdI->intrindx[jintr][0] == StdI->intrindx[kintr][4]
           && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][5]
           && StdI->intrindx[jintr][2] == StdI->intrindx[kintr][6]
           && StdI->intrindx[jintr][3] == StdI->intrindx[kintr][7]
           && StdI->intrindx[jintr][4] == StdI->intrindx[kintr][0]
           && StdI->intrindx[jintr][5] == StdI->intrindx[kintr][1]
           && StdI->intrindx[jintr][6] == StdI->intrindx[kintr][2]
-          && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][3])
+          && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][3]
+          && ! (  StdI->intrindx[jintr][0] == StdI->intrindx[jintr][6]
+               && StdI->intrindx[jintr][1] == StdI->intrindx[jintr][7])
+          && ! (  StdI->intrindx[jintr][2] == StdI->intrindx[jintr][4]
+               && StdI->intrindx[jintr][3] == StdI->intrindx[jintr][5])
+          )
         ) {
         StdI->intr[jintr] = StdI->intr[jintr] + StdI->intr[kintr];
         StdI->intr[kintr] = 0.0;
       }
       else if (
-        (StdI->intrindx[jintr][0] == StdI->intrindx[kintr][4]
+        (    StdI->intrindx[jintr][0] == StdI->intrindx[kintr][4]
           && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][5]
           && StdI->intrindx[jintr][2] == StdI->intrindx[kintr][2]
           && StdI->intrindx[jintr][3] == StdI->intrindx[kintr][3]
           && StdI->intrindx[jintr][4] == StdI->intrindx[kintr][0]
           && StdI->intrindx[jintr][5] == StdI->intrindx[kintr][1]
           && StdI->intrindx[jintr][6] == StdI->intrindx[kintr][6]
-          && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][7])
+          && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][7]
+          && ! (  StdI->intrindx[jintr][2] == StdI->intrindx[jintr][0]
+               && StdI->intrindx[jintr][3] == StdI->intrindx[jintr][1])
+          && ! (  StdI->intrindx[jintr][2] == StdI->intrindx[jintr][4]
+               && StdI->intrindx[jintr][3] == StdI->intrindx[jintr][5])
+          )
         ||
-        (StdI->intrindx[jintr][0] == StdI->intrindx[kintr][0]
+        (    StdI->intrindx[jintr][0] == StdI->intrindx[kintr][0]
           && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][1]
           && StdI->intrindx[jintr][2] == StdI->intrindx[kintr][6]
           && StdI->intrindx[jintr][3] == StdI->intrindx[kintr][7]
           && StdI->intrindx[jintr][4] == StdI->intrindx[kintr][4]
           && StdI->intrindx[jintr][5] == StdI->intrindx[kintr][5]
           && StdI->intrindx[jintr][6] == StdI->intrindx[kintr][2]
-          && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][3])
+          && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][3]
+          && ! (  StdI->intrindx[jintr][4] == StdI->intrindx[jintr][2]
+               && StdI->intrindx[jintr][5] == StdI->intrindx[jintr][3])
+          && ! (  StdI->intrindx[jintr][4] == StdI->intrindx[jintr][6]
+               && StdI->intrindx[jintr][5] == StdI->intrindx[jintr][7])
+          )
         ) {
         StdI->intr[jintr] = StdI->intr[jintr] - StdI->intr[kintr];
         StdI->intr[kintr] = 0.0;
       }
     }/*for (kintr = jintr + 1; kintr < StdI->nintr; kintr++)*/
   }/*for (jintr = 0; jintr < StdI->nintr; jintr++)*/
-
+  //
+  // Force Hermite term as
+  // (c1+ c2 c3+ c4)+ = c4+ c3 c2+ c1
+  //
   for (jintr = 0; jintr < StdI->nintr; jintr++) {
     for (kintr = jintr + 1; kintr < StdI->nintr; kintr++) {
-      if (StdI->intrindx[jintr][6] == StdI->intrindx[kintr][4]
+      if ( StdI->intrindx[jintr][6] == StdI->intrindx[kintr][4]
         && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][5]
         && StdI->intrindx[jintr][4] == StdI->intrindx[kintr][6]
         && StdI->intrindx[jintr][5] == StdI->intrindx[kintr][7]
@@ -2192,6 +2213,10 @@ static void PrintInteractions(struct StdIntList *StdI)
         && StdI->intrindx[jintr][3] == StdI->intrindx[kintr][1]
         && StdI->intrindx[jintr][0] == StdI->intrindx[kintr][2]
         && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][3]
+        && ! (  StdI->intrindx[kintr][0] == StdI->intrindx[kintr][6]
+             && StdI->intrindx[kintr][1] == StdI->intrindx[kintr][7])
+        && ! (  StdI->intrindx[kintr][2] == StdI->intrindx[kintr][4]
+             && StdI->intrindx[kintr][3] == StdI->intrindx[kintr][5])
         ) {
         StdI->intrindx[kintr][0] = StdI->intrindx[jintr][6];
         StdI->intrindx[kintr][1] = StdI->intrindx[jintr][7];
@@ -2203,23 +2228,33 @@ static void PrintInteractions(struct StdIntList *StdI)
         StdI->intrindx[kintr][7] = StdI->intrindx[jintr][1];
       }
       else if (
-        (StdI->intrindx[jintr][6] == StdI->intrindx[kintr][4]
+        (    StdI->intrindx[jintr][6] == StdI->intrindx[kintr][4]
           && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][5]
           && StdI->intrindx[jintr][4] == StdI->intrindx[kintr][2]
           && StdI->intrindx[jintr][5] == StdI->intrindx[kintr][3]
           && StdI->intrindx[jintr][2] == StdI->intrindx[kintr][0]
           && StdI->intrindx[jintr][3] == StdI->intrindx[kintr][1]
           && StdI->intrindx[jintr][0] == StdI->intrindx[kintr][6]
-          && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][7])
+          && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][7]
+          && ! (  StdI->intrindx[kintr][2] == StdI->intrindx[kintr][0]
+               && StdI->intrindx[kintr][3] == StdI->intrindx[kintr][1])
+          && ! (  StdI->intrindx[kintr][2] == StdI->intrindx[kintr][4]
+               && StdI->intrindx[kintr][3] == StdI->intrindx[kintr][5])
+          )
         ||
-        (StdI->intrindx[jintr][6] == StdI->intrindx[kintr][0]
+        (    StdI->intrindx[jintr][6] == StdI->intrindx[kintr][0]
           && StdI->intrindx[jintr][7] == StdI->intrindx[kintr][1]
           && StdI->intrindx[jintr][4] == StdI->intrindx[kintr][6]
           && StdI->intrindx[jintr][5] == StdI->intrindx[kintr][7]
           && StdI->intrindx[jintr][2] == StdI->intrindx[kintr][4]
           && StdI->intrindx[jintr][3] == StdI->intrindx[kintr][5]
           && StdI->intrindx[jintr][0] == StdI->intrindx[kintr][2]
-          && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][3])
+          && StdI->intrindx[jintr][1] == StdI->intrindx[kintr][3]
+          && ! (  StdI->intrindx[kintr][4] == StdI->intrindx[kintr][2]
+               && StdI->intrindx[kintr][5] == StdI->intrindx[kintr][3])
+          && ! (  StdI->intrindx[kintr][4] == StdI->intrindx[kintr][6]
+               && StdI->intrindx[kintr][5] == StdI->intrindx[kintr][7])
+          )
         ) {
         StdI->intrindx[kintr][0] = StdI->intrindx[jintr][6];
         StdI->intrindx[kintr][1] = StdI->intrindx[jintr][7];


### PR DESCRIPTION
スタンダードモードでInterallのファイルが生成される場合にｍ
c1+ c2 c3+ c4 = c3+ c4 c1+ c2 = - c1+ c4 c3+ c2 = - c3+ c2 c1+ c4
という演算子の入れ替えを許して相互作用を合算していたが、
沿え字が1=2, 3=4, 1=4, または3=2 の状況を考慮しておらず正しくない合算をしていた。(反交換のお釣りの項がないため)
このバグはS>1/2かつ自己相互作用(D項もしくは極端に短い周期)の場合に間違った解を生じる。

この修正では1=2, 3=4, 1=4, または3=2 には演算子の合算は行わないようにした。