### PR TITLE
[Bug Fix] スピンインデックスが逆に定義されていた

### DIFF
--- a/src/StdFace_ModelUtil.c
+++ b/src/StdFace_ModelUtil.c
@@ -132,8 +132,8 @@ void StdFace_HubbardLocal(
   int isite//!<[in] i for @f$c_{i \sigma}^\dagger@f$
 )
 {
-  StdFace_trans(StdI, mu0 + 0.5 * h0, isite, 0, isite, 0);
-  StdFace_trans(StdI, mu0 - 0.5 * h0, isite, 1, isite, 1);
+  StdFace_trans(StdI, mu0 - 0.5 * h0, isite, 0, isite, 0);
+  StdFace_trans(StdI, mu0 + 0.5 * h0, isite, 1, isite, 1);
   StdFace_trans(StdI, -0.5 * Gamma0, isite, 1, isite, 0);
   StdFace_trans(StdI, -0.5 * Gamma0, isite, 0, isite, 1);
   /**@brief
@@ -171,7 +171,7 @@ void StdFace_MagField(
      \sum_{\sigma = -S}^{S} -h\sigma c_{i \sigma}^\dagger c_{i \sigma}
     @f]
     */
-    Sz = (double)ispin - S;
+    Sz = S - (double)ispin;
     StdFace_trans(StdI, -h * Sz, isite, ispin, isite, ispin);
     /**@brief
     Transvars part
@@ -183,11 +183,11 @@ void StdFace_MagField(
     \sigma c_{i \sigma}^\dagger c_{i \sigma+1})
     @f]
     */
-    if (ispin < S2) {
+    if (ispin > 0) {
       StdFace_trans(StdI, -0.5 * Gamma * sqrt(S*(S + 1.0) - Sz*(Sz + 1.0)),
-        isite, ispin + 1, isite, ispin);
+        isite, ispin, isite, ispin - 1);
       StdFace_trans(StdI, -0.5 * Gamma * sqrt(S*(S + 1.0) - Sz*(Sz + 1.0)),
-        isite, ispin, isite, ispin + 1);
+        isite, ispin - 1, isite, ispin);
     }/*if (ispin < S2)*/
   }/*for (ispin = 0; ispin <= S2; ispin++)*/
 }/*void StdFace_MagField*/
@@ -297,9 +297,9 @@ struct StdIntList *StdI,//!<[inout]
   Sj = 0.5 * (double)Sj2;
 
   for (ispin = 0; ispin <= Si2; ispin++) {
-    Siz = (double)ispin - Si;
+    Siz = Si - (double)ispin;
     for (jspin = 0; jspin <= Sj2; jspin++) {
-      Sjz = (double)jspin - Sj;
+      Sjz = Sj - (double)jspin;
       /**@brief (1)
        @f[
        J_z S_{i z} * S_{j z} = J_z \sum_{\sigma, \sigma' = -S}^S
@@ -323,14 +323,14 @@ struct StdIntList *StdI,//!<[inout]
       I \equiv \frac{J_x + J_y + i(J_{xy} - J_{yx})}{4}
       @f]
       */
-      if ((ispin < Si2 && jspin < Sj2) && ExGeneral == 1) {
+      if ((ispin > 0 && jspin > 0) && ExGeneral == 1) {
         intr0 = 0.25 * (J[0][0] + J[1][1] + I*(J[0][1] - J[1][0]))
           * sqrt(Si * (Si + 1.0) - Siz * (Siz + 1.0))
           * sqrt(Sj * (Sj + 1.0) - Sjz * (Sjz + 1.0));
         StdFace_intr(StdI, intr0,
-          isite, ispin + 1, isite, ispin, jsite, jspin, jsite, jspin + 1);
+          isite, ispin - 1, isite, ispin, jsite, jspin, jsite, jspin - 1);
         StdFace_intr(StdI, conj(intr0),
-          isite, ispin, isite, ispin + 1, jsite, jspin + 1, jsite, jspin);
+          isite, ispin, isite, ispin - 1, jsite, jspin - 1, jsite, jspin);
       }
       /**@brief (3)
       @f[
@@ -343,14 +343,14 @@ struct StdIntList *StdI,//!<[inout]
       I \equiv \frac{J_x - J_y - i(J_{xy} + J_{yx})}{4}
       @f]
       */
-      if ((ispin < Si2 && jspin < Sj2) && ExGeneral == 1) {
+      if ((ispin > 0 && jspin > 0) && ExGeneral == 1) {
         intr0 = 0.5 * 0.5 * (J[0][0] - J[1][1] - I*(J[0][1] + J[1][0]))
           * sqrt(Si * (Si + 1.0) - Siz * (Siz + 1.0))
           * sqrt(Sj * (Sj + 1.0) - Sjz * (Sjz + 1.0));
         StdFace_intr(StdI, intr0,
-          isite, ispin + 1, isite, ispin, jsite, jspin + 1, jsite, jspin);
+          isite, ispin - 1, isite, ispin, jsite, jspin - 1, jsite, jspin);
         StdFace_intr(StdI, conj(intr0),
-          isite, ispin, isite, ispin + 1, jsite, jspin, jsite, jspin + 1);
+          isite, ispin, isite, ispin - 1, jsite, jspin, jsite, jspin - 1);
       }
       /**@brief (4)
       @f[
@@ -362,12 +362,12 @@ struct StdIntList *StdI,//!<[inout]
       I \equiv \frac{J_{xz} - i J_{yz}}{2}
       @f]
       */
-      if (ispin < Si2) {
+      if (ispin > 0) {
         intr0 = 0.5 * (J[0][2] - I * J[1][2]) * sqrt(Si * (Si + 1.0) - Siz * (Siz + 1.0)) * Sjz;
         StdFace_intr(StdI, intr0,
-          isite, ispin + 1, isite, ispin, jsite, jspin, jsite, jspin);
+          isite, ispin - 1, isite, ispin, jsite, jspin, jsite, jspin);
         StdFace_intr(StdI, conj(intr0),
-          jsite, jspin, jsite, jspin, isite, ispin, isite, ispin + 1);
+          jsite, jspin, jsite, jspin, isite, ispin, isite, ispin - 1);
       }/*if (ispin < Si2)*/
       /**@brief (5)
       @f[
@@ -379,12 +379,12 @@ struct StdIntList *StdI,//!<[inout]
        I \equiv \frac{J_{zx} - i J_{zy}}{2}
        @f]
       */
-      if (jspin < Sj2) {
+      if (jspin > 0) {
         intr0 = 0.5 * (J[2][0] - I * J[2][1]) * Siz * sqrt(Sj * (Sj + 1.0) - Sjz * (Sjz + 1.0));
         StdFace_intr(StdI, intr0,
-          isite, ispin, isite, ispin, jsite, jspin + 1, jsite, jspin);
+          isite, ispin, isite, ispin, jsite, jspin - 1, jsite, jspin);
         StdFace_intr(StdI, conj(intr0),
-          jsite, jspin, jsite, jspin + 1, isite, ispin, isite, ispin);
+          jsite, jspin, jsite, jspin - 1, isite, ispin, isite, ispin);
       }/*if (jspin < Sj2)*/
     }/*for (jspin = 0; jspin <= Sj2; jspin++)*/
   }/*for (ispin = 0; ispin <= Si2; ispin++)*/

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -347,18 +347,18 @@ static void PrintExcitation(struct StdIntList *StdI) {
       if (strcmp(StdI->model, "spin") == 0 && StdI->S2 > 1) {
         NumOp = StdI->S2;
         S = (double)StdI->S2 * 0.5;
-        for (ispin = 0; ispin < StdI->S2; ispin++) {
-          Sz = (double)ispin - (double)StdI->S2 * 0.5;
-          coef[ispin] = sqrt(S*(S + 1.0) - Sz*(Sz + 1.0));
-          spin[ispin][0] = ispin;
-          spin[ispin][1] = ispin + 1;
+        for (ispin = 1; ispin <= StdI->S2; ispin++) {
+          Sz = (double)StdI->S2 * 0.5 - (double)ispin;
+          coef[ispin-1] = sqrt(S*(S + 1.0) - Sz*(Sz + 1.0));
+          spin[ispin-1][0] = ispin;
+          spin[ispin-1][1] = ispin - 1;
         }
       }
       else {
         NumOp = 1;
         coef[0] = 1.0;
-        spin[0][0] = 0;
-        spin[0][1] = 1;
+        spin[0][0] = 1;
+        spin[0][1] = 0;
       }
       StdI->SpectrumBody = 2;
     }


### PR DESCRIPTION
※先日はマージどうもありがとうございました。

これまでのスタンダードモード
0=Down, 1=Up
だったが、マニュアルに書いてある通り正しくは
0=Up, 1=Down
また、S>1/2の場合もこれに関連して
0=最低スピン(-S)
だったのを
0=最大スピン(+S)
に定義した。