### PR TITLE
[BugFix] Kondo+greenr2k : 伝導電子サイトのインデックスが間違っていた

### DIFF
--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -926,11 +926,7 @@ static void StdFace_ResetVals(struct StdIntList *StdI) {
   for (i = 0; i < 3; i++)StdI->phase[i] = NaN_d;
   StdI->pi180 = StdI->pi / 180.0;
 
-#if defined(_HPhi)
-  StdI->nelec = StdI->NaN_i;
-#else
   StdI->ncond = StdI->NaN_i;
-#endif
   StdI->Sz2 = StdI->NaN_i;
   strcpy(StdI->model, "****\0");
   strcpy(StdI->lattice, "****\0");
@@ -1352,7 +1348,7 @@ static void PrintModPara(struct StdIntList *StdI)
   fprintf(fp, "--------------------\n");
   fprintf(fp, "Nsite          %-5d\n", StdI->nsite);
   if (StdI->Sz2 != StdI->NaN_i) fprintf(fp, "2Sz            %-5d\n", StdI->Sz2);
-  if (StdI->nelec != StdI->NaN_i) fprintf(fp, "Ncond          %-5d\n", StdI->nelec);
+  if (StdI->ncond != StdI->NaN_i) fprintf(fp, "Ncond          %-5d\n", StdI->ncond);
   fprintf(fp, "Lanczos_max    %-5d\n", StdI->Lanczos_max);
   fprintf(fp, "initial_iv     %-5d\n", StdI->initial_iv);
   if(StdI->nvec != StdI->NaN_i) fprintf(fp, "nvec           %-5d\n", StdI->nvec);
@@ -1851,9 +1847,9 @@ static void CheckModPara(struct StdIntList *StdI)
   */
   if (strcmp(StdI->model, "hubbard") == 0){
 #if defined(_HPhi)
-    if (StdI->lGC == 0) StdFace_RequiredVal_i("nelec", StdI->nelec);
+    if (StdI->lGC == 0) StdFace_RequiredVal_i("nelec", StdI->ncond);
     else {
-      StdFace_NotUsed_i("nelec", StdI->nelec);
+      StdFace_NotUsed_i("nelec", StdI->ncond);
       StdFace_NotUsed_i("2Sz", StdI->Sz2);
     }
 #else
@@ -1863,11 +1859,7 @@ static void CheckModPara(struct StdIntList *StdI)
 #endif
   }
   else if (strcmp(StdI->model, "spin") == 0) {
-#if defined(_HPhi)
-    StdFace_NotUsed_i("nelec", StdI->nelec);
-#else
     StdFace_NotUsed_i("ncond", StdI->ncond);
-#endif
 #if defined(_mVMC)
     StdI->ncond = 0;
 #endif
@@ -1876,9 +1868,9 @@ static void CheckModPara(struct StdIntList *StdI)
   }/*else if (strcmp(StdI->model, "spin") == 0)*/
   else if (strcmp(StdI->model, "kondo") == 0) {
 #if defined(_HPhi)
-    if (StdI->lGC == 0) StdFace_RequiredVal_i("nelec", StdI->nelec);
+    if (StdI->lGC == 0) StdFace_RequiredVal_i("ncond", StdI->ncond);
     else {
-      StdFace_NotUsed_i("nelec", StdI->nelec);
+      StdFace_NotUsed_i("nelec", StdI->ncond);
       StdFace_NotUsed_i("2Sz", StdI->Sz2);
     }
 #else
@@ -2570,7 +2562,8 @@ void StdFace_main(
     else if (strcmp(keyword, "lz") == 0) StoreWithCheckDup_d(keyword, value, &StdI->direct[1][2]);
     else if (strcmp(keyword, "model") == 0) StoreWithCheckDup_sl(keyword, value, StdI->model);
     else if (strcmp(keyword, "mu") == 0) StoreWithCheckDup_d(keyword, value, &StdI->mu);
-    // else if (strcmp(keyword, "nelec") == 0) StoreWithCheckDup_i(keyword, value, &StdI->nelec);
+    else if (strcmp(keyword, "ncond") == 0) StoreWithCheckDup_i(keyword, value, &StdI->ncond);
+    else if (strcmp(keyword, "nelec") == 0) StoreWithCheckDup_i(keyword, value, &StdI->ncond);
     else if (strcmp(keyword, "outputmode") == 0) StoreWithCheckDup_sl(keyword, value, StdI->outputmode);
     else if (strcmp(keyword, "phase0") == 0) StoreWithCheckDup_d(keyword, value, &StdI->phase[0]);
     else if (strcmp(keyword, "phase1") == 0) StoreWithCheckDup_d(keyword, value, &StdI->phase[1]);
@@ -2607,7 +2600,6 @@ void StdFace_main(
     else if (strcmp(keyword, "wz") == 0) StoreWithCheckDup_d(keyword, value, &StdI->direct[0][2]);
     else if (strcmp(keyword, "2sz") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Sz2);
 #if defined(_HPhi)
-    else if (strcmp(keyword, "nelec") == 0) StoreWithCheckDup_i(keyword, value, &StdI->nelec);
     else if (strcmp(keyword, "calcspec") == 0) StoreWithCheckDup_sl(keyword, value, StdI->CalcSpec);
     else if (strcmp(keyword, "exct") == 0) StoreWithCheckDup_i(keyword, value, &StdI->exct);
     else if (strcmp(keyword, "eigenvecio") == 0) StoreWithCheckDup_sl(keyword, value, StdI->EigenVecIO);
@@ -2647,7 +2639,6 @@ void StdFace_main(
     else if (strcmp(keyword, "vecpotw") == 0) StoreWithCheckDup_d(keyword, value, &StdI->VecPot[0]);
     else if (strcmp(keyword, "2s") == 0) StoreWithCheckDup_i(keyword, value, &StdI->S2);
 #elif defined(_mVMC)
-   else if (strcmp(keyword, "ncond") == 0) StoreWithCheckDup_i(keyword, value, &StdI->ncond);
     else if (strcmp(keyword, "a0hsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[0][2]);
     else if (strcmp(keyword, "a0lsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[0][1]);
     else if (strcmp(keyword, "a0wsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[0][0]);
@@ -2682,7 +2673,6 @@ void StdFace_main(
     else if (strcmp(keyword, "rndseed") == 0) StoreWithCheckDup_i(keyword, value, &StdI->RndSeed);
     else if (strcmp(keyword, "wsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Wsub);
 #elif defined(_UHF)
-   else if (strcmp(keyword, "ncond") == 0) StoreWithCheckDup_i(keyword, value, &StdI->ncond);
     else if (strcmp(keyword, "iteration_max") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Iteration_max);
     else if (strcmp(keyword, "rndseed") == 0) StoreWithCheckDup_i(keyword, value, &StdI->RndSeed);
     else if (strcmp(keyword, "nmptrans") == 0) StoreWithCheckDup_i(keyword, value, &StdI->NMPTrans);

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -1454,7 +1454,7 @@ static void Print1Green(struct StdIntList *StdI)
       if (StdI->ioutputmode == 1) {
         for (isite = 0; isite < StdI->NsiteUC*xkondo; isite++) {
 
-          if (isite >= StdI->NsiteUC) isite2 = isite + StdI->nsite / 2;
+          if (isite >= StdI->NsiteUC) isite2 = isite - StdI->NsiteUC + StdI->nsite / 2;
           else isite2 = isite;
 
           if (StdI->locspinflag[isite2] == 0) SiMax = 1;
@@ -1570,7 +1570,7 @@ static void Print2Green(struct StdIntList *StdI) {
 
       for (site1 = 0; site1 < StdI->NsiteUC*xkondo; site1++) {
 
-        if (site1 >= StdI->NsiteUC) site1k = site1 + StdI->nsite / 2;
+        if (site1 >= StdI->NsiteUC) site1k = site1 - StdI->NsiteUC + StdI->nsite / 2;
         else site1k = site1;
 
         if (StdI->locspinflag[site1k] == 0) S1Max = 1;

--- a/src/StdFace_vals.h
+++ b/src/StdFace_vals.h
@@ -230,6 +230,7 @@ struct StdIntList {
   /*
    Calculation conditions
   */
+  int ncond;/**<@brief Number of electrons, input from file.*/
   int lGC;/**<@brief Switch for computing Grandcanonical ensemble(== 1).
           Setted in StdFace_main() after all keywords are read.*/
   int S2;/**<@brief Total spin |S| of a local spin, input from file.*/
@@ -265,7 +266,6 @@ struct StdIntList {
   /*
   HPhi modpara
   */
-  int nelec;/**<@brief Number of electrons, input from file.*/
   char method[256];/**<@brief The name of method, input from file.*/
   char Restart[256];/**<@brief The name of restart mode, input from file.*/
   char InitialVecType[256];/**<@brief The name of initialguess-type, input from file.*/
@@ -326,7 +326,6 @@ struct StdIntList {
   int ExpandCoef;/**<@brief The number of Hamiltonian-vector operation for the time-evolution*/
 #elif defined(_mVMC)
   /*mVMC modpara*/
-  int ncond;/**<@brief Number of electrons, input from file.*/
   char CParaFileHead[256];/**<@brief Header of the optimized wavefunction,
                           input from file*/
   int NVMCCalMode;/**<@brief Optimization(=0) or compute correlation
@@ -371,7 +370,6 @@ struct StdIntList {
   int NSym;/**<@brief Number of translation symmetries, 
            Defined from the number of cells in the sub-lattice.*/
 #elif defined(_UHF)
-  int ncond;/**<@brief Number of electrons, input from file.*/
     int RndSeed;/**<@brief */
     double mix; /**<@brief linear mixing ratio for update*/
     int eps; /**<@brief convergence threshold for Green's functions */


### PR DESCRIPTION
greenr2kにgreenone.def, greentwo.defを食わせる場合には、局在スピン・伝導電子それぞれの各軌道についてR=0のサイトのものを左側の演算子にとる必要があるが、伝導電子ではそれが間違っていた。