### PR TITLE
Feature/fixes

### DIFF
--- a/src/FCOrtho.c
+++ b/src/FCOrtho.c
@@ -54,13 +54,13 @@ void StdFace_FCOrtho(
   StdFace_PrintVal_d("Llength", &StdI->length[1], StdI->a);
   StdFace_PrintVal_d("Hlength", &StdI->length[2], StdI->a);
   StdFace_PrintVal_d("Wx", &StdI->direct[0][0], 0.0);
-  StdFace_PrintVal_d("Wy", &StdI->direct[0][1], 0.5 * StdI->length[0]);
-  StdFace_PrintVal_d("Wz", &StdI->direct[0][2], 0.5 * StdI->length[0]);
-  StdFace_PrintVal_d("Lx", &StdI->direct[1][0], 0.5 * StdI->length[1]);
+  StdFace_PrintVal_d("Wy", &StdI->direct[0][1], 0.5 * StdI->length[1]);
+  StdFace_PrintVal_d("Wz", &StdI->direct[0][2], 0.5 * StdI->length[2]);
+  StdFace_PrintVal_d("Lx", &StdI->direct[1][0], 0.5 * StdI->length[0]);
   StdFace_PrintVal_d("Ly", &StdI->direct[1][1], 0.0);
-  StdFace_PrintVal_d("Lz", &StdI->direct[1][2], 0.5 * StdI->length[1]);
-  StdFace_PrintVal_d("Hx", &StdI->direct[2][0], 0.5 * StdI->length[2]);
-  StdFace_PrintVal_d("Hy", &StdI->direct[2][1], 0.5 * StdI->length[2]);
+  StdFace_PrintVal_d("Lz", &StdI->direct[1][2], 0.5 * StdI->length[2]);
+  StdFace_PrintVal_d("Hx", &StdI->direct[2][0], 0.5 * StdI->length[0]);
+  StdFace_PrintVal_d("Hy", &StdI->direct[2][1], 0.5 * StdI->length[1]);
   StdFace_PrintVal_d("Hz", &StdI->direct[2][2], 0.0);
 
   StdFace_PrintVal_d("phase0", &StdI->phase[0], 0.0);

--- a/src/Orthorhombic.c
+++ b/src/Orthorhombic.c
@@ -61,7 +61,7 @@ void StdFace_Orthorhombic(
   StdFace_PrintVal_d("Lz", &StdI->direct[1][2], 0.0);
   StdFace_PrintVal_d("Hx", &StdI->direct[2][0], 0.0);
   StdFace_PrintVal_d("Hy", &StdI->direct[2][1], 0.0);
-  StdFace_PrintVal_d("Hz", &StdI->direct[2][2], StdI->length[1]);
+  StdFace_PrintVal_d("Hz", &StdI->direct[2][2], StdI->length[2]);
 
   StdFace_PrintVal_d("phase0", &StdI->phase[0], 0.0);
   StdFace_PrintVal_d("phase1", &StdI->phase[1], 0.0);

--- a/src/Pyrochlore.c
+++ b/src/Pyrochlore.c
@@ -54,13 +54,13 @@ void StdFace_Pyrochlore(
   StdFace_PrintVal_d("Llength", &StdI->length[1], StdI->a);
   StdFace_PrintVal_d("Hlength", &StdI->length[2], StdI->a);
   StdFace_PrintVal_d("Wx", &StdI->direct[0][0], 0.0);
-  StdFace_PrintVal_d("Wy", &StdI->direct[0][1], 0.5 * StdI->length[0]);
-  StdFace_PrintVal_d("Wz", &StdI->direct[0][2], 0.5 * StdI->length[0]);
-  StdFace_PrintVal_d("Lx", &StdI->direct[1][0], 0.5 * StdI->length[1]);
+  StdFace_PrintVal_d("Wy", &StdI->direct[0][1], 0.5 * StdI->length[1]);
+  StdFace_PrintVal_d("Wz", &StdI->direct[0][2], 0.5 * StdI->length[2]);
+  StdFace_PrintVal_d("Lx", &StdI->direct[1][0], 0.5 * StdI->length[0]);
   StdFace_PrintVal_d("Ly", &StdI->direct[1][1], 0.0);
-  StdFace_PrintVal_d("Lz", &StdI->direct[1][2], 0.5 * StdI->length[1]);
-  StdFace_PrintVal_d("Hx", &StdI->direct[2][0], 0.5 * StdI->length[2]);
-  StdFace_PrintVal_d("Hy", &StdI->direct[2][1], 0.5 * StdI->length[2]);
+  StdFace_PrintVal_d("Lz", &StdI->direct[1][2], 0.5 * StdI->length[2]);
+  StdFace_PrintVal_d("Hx", &StdI->direct[2][0], 0.5 * StdI->length[0]);
+  StdFace_PrintVal_d("Hy", &StdI->direct[2][1], 0.5 * StdI->length[1]);
   StdFace_PrintVal_d("Hz", &StdI->direct[2][2], 0.0);
 
   StdFace_PrintVal_d("phase0", &StdI->phase[0], 0.0);

--- a/src/StdFace_ModelUtil.c
+++ b/src/StdFace_ModelUtil.c
@@ -943,7 +943,17 @@ void StdFace_PrintXSF(struct StdIntList *StdI) {
   FILE *fp;
   int ii, jj, kk, isite, iCell;
   double vec[3];
+  int do_convvec;
 
+  do_convvec = 0;
+  if (strcmp(StdI->lattice, "orthorhombic") == 0
+      || strcmp(StdI->lattice, "face-centeredorthorhombic") == 0
+      || strcmp(StdI->lattice, "fcorthorhombic") == 0
+      || strcmp(StdI->lattice, "fco") == 0
+      || strcmp(StdI->lattice, "pyrochlore") == 0) {
+    do_convvec = 1;
+  }
+  
   fp = fopen("lattice.xsf", "w");
   fprintf(fp, "CRYSTAL\n");
   fprintf(fp, "PRIMVEC\n");
@@ -954,6 +964,19 @@ void StdFace_PrintXSF(struct StdIntList *StdI) {
         vec[jj] += (double)StdI->box[ii][kk] * StdI->direct[kk][jj];
     }
     fprintf(fp, "%15.5f %15.5f %15.5f\n", vec[0], vec[1], vec[2]);
+  }
+  if (do_convvec) {
+    fprintf(fp, "CONVVEC\n");
+    for (ii = 0; ii < 3; ++ii) {
+      for (jj = 0; jj < 3; ++jj) {
+        if (ii == jj) {
+          fprintf(fp, "%15.5f ", StdI->length[ii]);
+        } else {
+          fprintf(fp, "%15.5f ", 0.0);
+        }
+      }
+      fprintf(fp, "\n");
+    }
   }
   fprintf(fp, "PRIMCOORD\n");
   fprintf(fp, "%d 1\n", StdI->NCell * StdI->NsiteUC);

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -83,7 +83,7 @@ static void PrintCalcMod(struct StdIntList *StdI)
 {
   FILE *fp;
   int iCalcType, iCalcModel, iRestart, iCalcSpec, 
-    iCalcEigenvec, iInitialVecTpye, InputEigenVec, OutputEigenVec,
+    iCalcEigenvec, iInitialVecType, InputEigenVec, OutputEigenVec,
     iInputHam, iOutputHam, iOutputExVec;
   /*
   First, check all parameters and exit if invalid parameters
@@ -155,14 +155,14 @@ static void PrintCalcMod(struct StdIntList *StdI)
     strcpy(StdI->InitialVecType, "c\0");
     fprintf(stdout, "   InitialVecType = c           ######  DEFAULT VALUE IS USED  ######\n");
     if (strcmp(StdI->method, "tpq") == 0 || strcmp(StdI->method, "ctpq") == 0)
-      iInitialVecTpye = -1;
+      iInitialVecType = -1;
     else
-      iInitialVecTpye = 0;
+      iInitialVecType = 0;
   }/*if (strcmp(StdI->InitialVecType, "****") == 0)*/
   else {
     fprintf(stdout, "   InitialVecType = %s\n", StdI->InitialVecType);
-    if (strcmp(StdI->InitialVecType, "c") == 0) iInitialVecTpye = 0;
-    else if (strcmp(StdI->InitialVecType, "r") == 0) iInitialVecTpye = 1;
+    if (strcmp(StdI->InitialVecType, "c") == 0) iInitialVecType = 0;
+    else if (strcmp(StdI->InitialVecType, "r") == 0) iInitialVecType = 1;
     else {
       fprintf(stdout, "\n ERROR ! Restart Mode : %s\n", StdI->Restart);
       StdFace_exit(-1);
@@ -285,7 +285,7 @@ static void PrintCalcMod(struct StdIntList *StdI)
   fprintf(fp, "ReStart %3d\n", iRestart);
   fprintf(fp, "CalcSpec %3d\n", iCalcSpec);
   fprintf(fp, "CalcEigenVec %3d\n", iCalcEigenvec);
-  fprintf(fp, "InitialVecType %3d\n", iInitialVecTpye);
+  fprintf(fp, "InitialVecType %3d\n", iInitialVecType);
   fprintf(fp, "InputEigenVec %3d\n", InputEigenVec);
   fprintf(fp, "OutputEigenVec %3d\n", OutputEigenVec);
   fprintf(fp, "InputHam %3d\n", iInputHam);

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -1549,7 +1549,7 @@ static void Print1Green(struct StdIntList *StdI)
           }/*for (ispin = 0; ispin <= SiMax; ispin++)*/
         }/*for (isite = 0; isite < StdI->nsite; isite++)*/
       }/*if (StdI->ioutputmode == 2)*/
-    }/*if (StdI->ioutputmode != 0)*/
+    }/*for (store = 0; store < 2; store++))*/
 
     fp = fopen("greenone.def", "w");
     fprintf(fp, "===============================\n");

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -1842,7 +1842,7 @@ static void CheckModPara(struct StdIntList *StdI)
     StdFace_NotUsed_i("NSPStot", StdI->NSPStot);
   }
  
-  if (StdI->AntiPeriod[0] == 1 || StdI->AntiPeriod[1] == 1 || StdI->AntiPeriod[2] == 2)
+  if (StdI->AntiPeriod[0] == 1 || StdI->AntiPeriod[1] == 1 || StdI->AntiPeriod[2] == 1)
     StdFace_PrintVal_i("NMPTrans", &StdI->NMPTrans, -1);
   else StdFace_PrintVal_i("NMPTrans", &StdI->NMPTrans, 1);
 

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -2727,6 +2727,9 @@ void StdFace_main(
     else if (strcmp(keyword, "hsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Hsub);
     else if (strcmp(keyword, "lsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Lsub);
     else if (strcmp(keyword, "wsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Wsub);
+    else if (strcmp(keyword, "eps") == 0) StoreWithCheckDup_i(keyword, value, &StdI->eps);
+    else if (strcmp(keyword, "epsslater") == 0) StoreWithCheckDup_i(keyword, value, &StdI->eps_slater);
+    else if (strcmp(keyword, "mix") == 0) StoreWithCheckDup_d(keyword, value, &StdI->mix);
 #endif
     else {
       fprintf(stdout, "ERROR ! Unsupported Keyword in Standard mode!\n");


### PR DESCRIPTION
several mainly typographical errors are corrected; 
the default values given to direct[][] array in FCO and Pyrochlore lattices seem to be transposed.