### PR TITLE
Hwave mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ if(HPHI)
 add_definitions(-D_HPhi)
 endif(HPHI)
 
+if(HWAVE)
+add_definitions(-D_HWAVE)
+endif(HWAVE)
+
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # StdFace
 
-An input files generator for [HPhi](https://github.com/issp-center-dev/HPhi), [mVMC](https://github.com/issp-center-dev/mVMC) and [UHF](https://github.com/issp-center-dev/UHF-dev).
+An input files generator for
+[HPhi](https://github.com/issp-center-dev/HPhi),
+[mVMC](https://github.com/issp-center-dev/mVMC),
+[UHF](https://github.com/issp-center-dev/UHF-dev), and
+[H-wave](https://github.com/issp-center-dev/H-wave).
 
 ## Requirement
 C compiler (intel, Fujitsu, GNU, etc. )  
@@ -31,6 +35,7 @@ $ make install
 If you define xxx as HPHI, hphi_dry.out is made.
 If you define xxx as MVMC, mvmc_dry.out is made.
 If you define xxx as UHF, uhf_dry.out is made.
+If you define xxx as HWAVE, hwave_dry.out is made.
 
 ## Licence
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,3 +34,9 @@ if (HPHI)
    install(TARGETS hphi_dry.out RUNTIME DESTINATION bin)
 endif(HPHI)
 
+if (HWAVE)
+   add_executable(hwave_dry.out dry.c)
+   target_link_libraries(hwave_dry.out StdFace m)
+   install(TARGETS hwave_dry.out RUNTIME DESTINATION bin)
+endif(HWAVE)
+

--- a/src/ChainLattice.c
+++ b/src/ChainLattice.c
@@ -34,7 +34,7 @@ void StdFace_Chain(
   struct StdIntList *StdI//!<[inout]
 )
 {
-  FILE *fp;
+  FILE *fp = NULL;
   int isite, jsite, ntransMax, nintrMax;
   int iL;
   double complex Cphase;
@@ -43,6 +43,9 @@ void StdFace_Chain(
   /**@brief
   (1) Compute the shape of the super-cell and sites in the super-cell
   */
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1)
+#endif
   fp = fopen("lattice.gp", "w");
   /**/
   StdI->NsiteUC = 1;
@@ -224,8 +227,14 @@ void StdFace_Chain(
     }
   }/*for (iL = 0; iL < StdI->L; iL++)*/
 
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1) {
+#endif
   fprintf(fp, "plot \'-\' w d lc 7\n0.0 0.0\nend\npause -1\n");
   fclose(fp);
+#ifdef _HWAVE
+  }
+#endif
   StdFace_PrintGeometry(StdI);
 }/*void StdFace_Chain*/
 

--- a/src/HoneycombLattice.c
+++ b/src/HoneycombLattice.c
@@ -34,13 +34,16 @@ void StdFace_Honeycomb(struct StdIntList *StdI)
 {
   int isite, jsite, kCell, ntransMax, nintrMax;
   int iL, iW;
-  FILE *fp;
+  FILE *fp = NULL;
   double complex Cphase;
   double dR[3];
 
   /**@brief
   (1) Compute the shape of the super-cell and sites in the super-cell
   */
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1)
+#endif
   fp = fopen("lattice.gp", "w");
   /**/
   StdI->NsiteUC = 2;
@@ -355,8 +358,14 @@ void StdFace_Honeycomb(struct StdIntList *StdI)
     }
   }/*for (kCell = 0; kCell < StdI->NCell; kCell++)*/
 
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1) {
+#endif
   fprintf(fp, "plot \'-\' w d lc 7\n0.0 0.0\nend\npause -1\n");
   fclose(fp);
+#ifdef _HWAVE
+  }
+#endif
   StdFace_PrintGeometry(StdI);
 }/*void StdFace_Honeycomb*/
 

--- a/src/Kagome.c
+++ b/src/Kagome.c
@@ -36,13 +36,16 @@ void StdFace_Kagome(
 {
   int isite, jsite, isiteUC, kCell, ntransMax, nintrMax;
   int iL, iW;
-  FILE *fp;
+  FILE *fp = NULL;
   double complex Cphase;
   double dR[3];
 
   /**@brief
   (1) Compute the shape of the super-cell and sites in the super-cell
   */
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1)
+#endif
   fp = fopen("lattice.gp", "w");
   /**/
   StdI->NsiteUC = 3;
@@ -352,8 +355,14 @@ void StdFace_Kagome(
     }
   }/*for (kCell = 0; kCell < StdI->NCell; kCell++)*/
 
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1) {
+#endif
   fprintf(fp, "plot \'-\' w d lc 7\n0.0 0.0\nend\npause -1\n");
   fclose(fp);
+#ifdef _HWAVE
+  }
+#endif
   StdFace_PrintGeometry(StdI);
 }/*void StdFace_Kagome*/
 

--- a/src/Ladder.c
+++ b/src/Ladder.c
@@ -34,7 +34,7 @@ void StdFace_Ladder(
   struct StdIntList *StdI//!<[inout]
 )
 {
-  FILE *fp;
+  FILE *fp = NULL;
   int isite, jsite, ntransMax, nintrMax;
   int iL, isiteUC;
   double complex Cphase;
@@ -43,6 +43,9 @@ void StdFace_Ladder(
   /**@brief
   (1) Compute the shape of the super-cell and sites in the super-cell
   */
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1)
+#endif
   fp = fopen("lattice.gp", "w");
   /**/
   fprintf(stdout, "  @ Lattice Size & Shape\n\n");
@@ -276,8 +279,14 @@ void StdFace_Ladder(
     }/*for (isiteUC = 0; isiteUC < StdI->NsiteUC; isiteUC++)*/
   }/*for (iL = 0; iL < StdI->L; iL++)*/
 
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1) {
+#endif
   fprintf(fp, "plot \'-\' w d lc 7\n0.0 0.0\nend\npause -1\n");
   fclose(fp);
+#ifdef _HWAVE
+  }
+#endif
   StdFace_PrintGeometry(StdI);
 }/*void StdFace_Ladder*/
 

--- a/src/SquareLattice.c
+++ b/src/SquareLattice.c
@@ -34,13 +34,16 @@ void StdFace_Tetragonal(struct StdIntList *StdI)
 {
   int isite, jsite, ntransMax, nintrMax;
   int iL, iW, kCell;
-  FILE *fp;
+  FILE *fp = NULL;
   double complex Cphase;
   double dR[3];
 
   /**@brief
   (1) Compute the shape of the super-cell and sites in the super-cell
   */
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1)
+#endif
   fp = fopen("lattice.gp", "w");
   /**/
   StdI->NsiteUC = 1;
@@ -274,7 +277,13 @@ void StdFace_Tetragonal(struct StdIntList *StdI)
     }
   }/*for (kCell = 0; kCell < StdI->NCell; kCell++)*/
 
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1) {
+#endif
   fprintf(fp, "plot \'-\' w d lc 7\n0.0 0.0\nend\npause -1\n");
   fclose(fp);
+#ifdef _HWAVE
+  }
+#endif
   StdFace_PrintGeometry(StdI);
 }

--- a/src/StdFace_ModelUtil.c
+++ b/src/StdFace_ModelUtil.c
@@ -1183,7 +1183,7 @@ void StdFace_InputHopp(
 */
 void StdFace_PrintGeometry(struct StdIntList *StdI) {
 
-#if defined(_UHF)
+#if defined(_HWAVE)
   if (strcmp(StdI->calcmode, "uhfk") == 0) {
     /* suppress output geometry.dat in UHFk mode */
   } else {
@@ -1226,7 +1226,7 @@ void StdFace_PrintGeometry(struct StdIntList *StdI) {
   fflush(fp);
   fclose(fp);
 
-#if defined(_UHF)
+#if defined(_HWAVE)
   }
 #endif
 

--- a/src/StdFace_ModelUtil.c
+++ b/src/StdFace_ModelUtil.c
@@ -799,24 +799,26 @@ void StdFace_InitSite(
     xmin -= 2.0;
     xmax += 2.0;
 
-    fprintf(fp, "#set terminal pdf color enhanced \\\n");
-    fprintf(fp, "#dashed dl 1.0 size 20.0cm, 20.0cm \n");
-    fprintf(fp, "#set output \"lattice.pdf\"\n");
-    fprintf(fp, "set xrange [%f: %f]\n", xmin, xmax);
-    fprintf(fp, "set yrange [%f: %f]\n", xmin, xmax);
-    fprintf(fp, "set size square\n");
-    fprintf(fp, "unset key\n");
-    fprintf(fp, "unset tics\n");
-    fprintf(fp, "unset border\n");
+    if (fp) {
+      fprintf(fp, "#set terminal pdf color enhanced \\\n");
+      fprintf(fp, "#dashed dl 1.0 size 20.0cm, 20.0cm \n");
+      fprintf(fp, "#set output \"lattice.pdf\"\n");
+      fprintf(fp, "set xrange [%f: %f]\n", xmin, xmax);
+      fprintf(fp, "set yrange [%f: %f]\n", xmin, xmax);
+      fprintf(fp, "set size square\n");
+      fprintf(fp, "unset key\n");
+      fprintf(fp, "unset tics\n");
+      fprintf(fp, "unset border\n");
 
-    fprintf(fp, "set style line 1 lc 1 lt 1\n");
-    fprintf(fp, "set style line 2 lc 5 lt 1\n");
-    fprintf(fp, "set style line 3 lc 0 lt 1\n");
+      fprintf(fp, "set style line 1 lc 1 lt 1\n");
+      fprintf(fp, "set style line 2 lc 5 lt 1\n");
+      fprintf(fp, "set style line 3 lc 0 lt 1\n");
 
-    fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[0][0], pos[0][1], pos[1][0], pos[1][1]);
-    fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[1][0], pos[1][1], pos[3][0], pos[3][1]);
-    fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[3][0], pos[3][1], pos[2][0], pos[2][1]);
-    fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[2][0], pos[2][1], pos[0][0], pos[0][1]);
+      fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[0][0], pos[0][1], pos[1][0], pos[1][1]);
+      fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[1][0], pos[1][1], pos[3][0], pos[3][1]);
+      fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[3][0], pos[3][1], pos[2][0], pos[2][1]);
+      fprintf(fp, "set arrow from %f, %f to %f, %f nohead front ls 3\n", pos[2][0], pos[2][1], pos[0][0], pos[0][1]);
+    }
   }/*if (dim == 2)*/
 }/*void StdFace_InitSite2D*/
 /**
@@ -908,12 +910,21 @@ void StdFace_SetLabel(
   yj = StdI->direct[0][1] * ((double)(iW - diW) + StdI->tau[isiteUC][0])
      + StdI->direct[1][1] * ((double)(iL - diL) + StdI->tau[isiteUC][1]);
 
-  if (*isite < 10)fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *isite, xi, yi);
-  else            fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *isite, xi, yi);
-  if (*jsite < 10)fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *jsite, xj, yj);
-  else            fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *jsite, xj, yj);
-  if (connect < 3)
-    fprintf(fp, "set arrow from %f, %f to %f, %f nohead ls %d\n", xi, yi, xj, yj, connect);
+  if (fp) {
+    if (*isite < 10) {
+      fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *isite, xi, yi);
+    } else {
+      fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *isite, xi, yi);
+    }
+    if (*jsite < 10) {
+      fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *jsite, xj, yj);
+    } else {
+      fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *jsite, xj, yj);
+    }
+    if (connect < 3) {
+      fprintf(fp, "set arrow from %f, %f to %f, %f nohead ls %d\n", xi, yi, xj, yj, connect);
+    }
+  }
   /**@brief
   Then print the normal one, these are different when they cross boundary.
   */
@@ -929,12 +940,21 @@ void StdFace_SetLabel(
   yj = StdI->direct[0][1] * ((double)(iW + diW) + StdI->tau[jsiteUC][0])
      + StdI->direct[1][1] * ((double)(iL + diL) + StdI->tau[jsiteUC][1]);
 
-  if (*isite < 10)fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *isite, xi, yi);
-  else            fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *isite, xi, yi);
-  if (*jsite < 10)fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *jsite, xj, yj);
-  else            fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *jsite, xj, yj);
-  if (connect < 3)
-    fprintf(fp, "set arrow from %f, %f to %f, %f nohead ls %d\n", xi, yi, xj, yj, connect);
+  if (fp) {
+    if (*isite < 10) {
+      fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *isite, xi, yi);
+    } else {
+      fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *isite, xi, yi);
+    }
+    if (*jsite < 10) {
+      fprintf(fp, "set label \"%1d\" at %f, %f center front\n", *jsite, xj, yj);
+    } else {
+      fprintf(fp, "set label \"%2d\" at %f, %f center front\n", *jsite, xj, yj);
+    }
+    if (connect < 3) {
+      fprintf(fp, "set arrow from %f, %f to %f, %f nohead ls %d\n", xi, yi, xj, yj, connect);
+    }
+  }
 }/*void StdFace_SetLabel*/
 /**
 @brief Print lattice.xsf (XCrysDen format) 
@@ -1184,7 +1204,7 @@ void StdFace_InputHopp(
 void StdFace_PrintGeometry(struct StdIntList *StdI) {
 
 #if defined(_HWAVE)
-  if (strcmp(StdI->calcmode, "uhfk") == 0) {
+  if (strcmp(StdI->calcmode, "uhfk") == 0 || strcmp(StdI->calcmode, "rpa") == 0) {
     /* suppress output geometry.dat in UHFk mode */
   } else {
 #endif

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -1139,6 +1139,7 @@ static void StdFace_ResetVals(struct StdIntList *StdI) {
   strcpy(StdI->calcmode, "****\0");
   strcpy(StdI->fileprefix, "****\0");
   StdI->export_all = StdI->NaN_i;
+  StdI->lattice_gp = StdI->NaN_i;
 #endif
 }/*static void StdFace_ResetVals*/
 /*
@@ -2850,6 +2851,7 @@ void StdFace_main(
     else if (strcmp(keyword, "calcmode") == 0) StoreWithCheckDup_sl(keyword, value, StdI->calcmode);
     else if (strcmp(keyword, "fileprefix") == 0) StoreWithCheckDup_sl(keyword, value, StdI->fileprefix);
     else if (strcmp(keyword, "exportall") == 0) StoreWithCheckDup_i(keyword, value, &StdI->export_all);
+    else if (strcmp(keyword, "lattice_gp") == 0) StoreWithCheckDup_i(keyword, value, &StdI->lattice_gp);
 #endif
     else {
       fprintf(stdout, "ERROR ! Unsupported Keyword in Standard mode!\n");
@@ -3031,7 +3033,7 @@ void StdFace_main(
 
 #elif defined(_HWAVE)
   if (strcmp(StdI->calcmode, "uhfk") == 0
-      || strcmp(StdI->calcmode, "rpa") == 0
+      || strcmp(StdI->calcmode, "rpa") == 0)
   {
     /* UHFk or RPA mode */
     ExportGeometry(StdI);

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -3032,15 +3032,9 @@ void StdFace_main(
   PrintNamelist(StdI);
 
 #elif defined(_HWAVE)
-  if (strcmp(StdI->calcmode, "uhfk") == 0
-      || strcmp(StdI->calcmode, "rpa") == 0)
+  if (strcmp(StdI->calcmode, "uhfr") == 0)
   {
-    /* UHFk or RPA mode */
-    ExportGeometry(StdI);
-    ExportInteraction(StdI);
-
-  } else {
-    /* otherwise (UHFr) */
+    /* UHFr mode */
 
     /* PrintLocSpin(StdI); */
     PrintTrans(StdI);
@@ -3053,7 +3047,13 @@ void StdFace_main(
 
     /* PrintNamelist(StdI); */
 
+  } else {
+    /* UHFk or RPA mode */
+    ExportGeometry(StdI);
+    ExportInteraction(StdI);
+
   }
+
 #endif
   /*
   Finalize All

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -40,7 +40,7 @@ The following lattices are supported:
 #include "StdFace_vals.h"
 #include "StdFace_ModelUtil.h"
 #include <complex.h>
-#if defined(_UHF)
+#if defined(_HWAVE)
 #include "export_wannier90.h"
 #endif
 
@@ -1123,6 +1123,19 @@ static void StdFace_ResetVals(struct StdIntList *StdI) {
   StdI->Hsub = StdI->NaN_i;
   StdI->Lsub = StdI->NaN_i;
   StdI->Wsub = StdI->NaN_i;
+#elif defined(_HWAVE)
+  StdI->NMPTrans = StdI->NaN_i;
+  StdI->RndSeed = StdI->NaN_i;
+  StdI->mix = NaN_d;
+  StdI->eps = StdI->NaN_i;
+  StdI->eps_slater = StdI->NaN_i;
+  StdI->Iteration_max = StdI->NaN_i;
+  for (i = 0; i < 3; i++)
+    for (j = 0; j < 3; j++)
+      StdI->boxsub[i][j] = StdI->NaN_i;
+  StdI->Hsub = StdI->NaN_i;
+  StdI->Lsub = StdI->NaN_i;
+  StdI->Wsub = StdI->NaN_i;
   strcpy(StdI->calcmode, "****\0");
   strcpy(StdI->fileprefix, "****\0");
   StdI->export_all = StdI->NaN_i;
@@ -1500,6 +1513,21 @@ static void PrintModPara(struct StdIntList *StdI)
   fprintf(fp, "NSRCG          %d\n", StdI->NSRCG);
 #elif defined(_UHF)
   fprintf(fp, "UHF_Cal_Parameters\n");
+  fprintf(fp, "--------------------\n");
+  fprintf(fp, "CDataFileHead  %s\n", StdI->CDataFileHead);
+  fprintf(fp, "CParaFileHead  zqp\n");
+  fprintf(fp, "--------------------\n");
+  fprintf(fp, "Nsite          %d\n", StdI->nsite);
+  if (StdI->Sz2 != StdI->NaN_i) fprintf(fp, "2Sz            %-5d\n", StdI->Sz2);
+  fprintf(fp, "Ncond          %-5d\n", StdI->ncond);
+  fprintf(fp, "IterationMax   %d\n", StdI->Iteration_max);
+  fprintf(fp, "EPS            %d\n", StdI->eps);
+  fprintf(fp, "Mix            %.10f\n", StdI->mix);
+  fprintf(fp, "RndSeed        %d\n", StdI->RndSeed);
+  fprintf(fp, "EpsSlater      %d\n", StdI->eps_slater);
+  fprintf(fp, "NMPTrans       %d\n", StdI->NMPTrans);
+#elif defined(_HWAVE)
+  fprintf(fp, "HWAVE_Cal_Parameters\n");
   fprintf(fp, "--------------------\n");
   fprintf(fp, "CDataFileHead  %s\n", StdI->CDataFileHead);
   fprintf(fp, "CParaFileHead  zqp\n");
@@ -1935,6 +1963,13 @@ static void CheckModPara(struct StdIntList *StdI)
   StdFace_PrintVal_d("DSROptStaDel", &StdI->DSROptStaDel, 0.02);
   StdFace_PrintVal_d("DSROptStepDt", &StdI->DSROptStepDt, 0.02);
 #elif defined(_UHF)
+  StdFace_PrintVal_i("RndSeed", &StdI->RndSeed, 123456789);
+  StdFace_PrintVal_i("Iteration_max", &StdI->Iteration_max, 1000);
+  StdFace_PrintVal_d("Mix", &StdI->mix, 0.5);
+  StdFace_PrintVal_i("eps", &StdI->eps, 8);
+  StdFace_PrintVal_i("EpsSlater", &StdI->eps_slater, 6);
+  StdFace_PrintVal_i("NMPTrans", &StdI->NMPTrans, 0);
+#elif defined(_HWAVE)
   StdFace_PrintVal_i("RndSeed", &StdI->RndSeed, 123456789);
   StdFace_PrintVal_i("Iteration_max", &StdI->Iteration_max, 1000);
   StdFace_PrintVal_d("Mix", &StdI->mix, 0.5);
@@ -2793,6 +2828,25 @@ void StdFace_main(
     else if (strcmp(keyword, "eps") == 0) StoreWithCheckDup_i(keyword, value, &StdI->eps);
     else if (strcmp(keyword, "epsslater") == 0) StoreWithCheckDup_i(keyword, value, &StdI->eps_slater);
     else if (strcmp(keyword, "mix") == 0) StoreWithCheckDup_d(keyword, value, &StdI->mix);
+#elif defined(_HWAVE)
+    else if (strcmp(keyword, "iteration_max") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Iteration_max);
+    else if (strcmp(keyword, "rndseed") == 0) StoreWithCheckDup_i(keyword, value, &StdI->RndSeed);
+    else if (strcmp(keyword, "nmptrans") == 0) StoreWithCheckDup_i(keyword, value, &StdI->NMPTrans);
+    else if (strcmp(keyword, "a0hsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[0][2]);
+    else if (strcmp(keyword, "a0lsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[0][1]);
+    else if (strcmp(keyword, "a0wsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[0][0]);
+    else if (strcmp(keyword, "a1hsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[1][2]);
+    else if (strcmp(keyword, "a1lsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[1][1]);
+    else if (strcmp(keyword, "a1wsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[1][0]);
+    else if (strcmp(keyword, "a2hsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[2][2]);
+    else if (strcmp(keyword, "a2lsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[2][1]);
+    else if (strcmp(keyword, "a2wsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->boxsub[2][0]);
+    else if (strcmp(keyword, "hsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Hsub);
+    else if (strcmp(keyword, "lsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Lsub);
+    else if (strcmp(keyword, "wsub") == 0) StoreWithCheckDup_i(keyword, value, &StdI->Wsub);
+    else if (strcmp(keyword, "eps") == 0) StoreWithCheckDup_i(keyword, value, &StdI->eps);
+    else if (strcmp(keyword, "epsslater") == 0) StoreWithCheckDup_i(keyword, value, &StdI->eps_slater);
+    else if (strcmp(keyword, "mix") == 0) StoreWithCheckDup_d(keyword, value, &StdI->mix);
     else if (strcmp(keyword, "calcmode") == 0) StoreWithCheckDup_sl(keyword, value, StdI->calcmode);
     else if (strcmp(keyword, "fileprefix") == 0) StoreWithCheckDup_sl(keyword, value, StdI->fileprefix);
     else if (strcmp(keyword, "exportall") == 0) StoreWithCheckDup_i(keyword, value, &StdI->export_all);
@@ -2964,23 +3018,38 @@ void StdFace_main(
   PrintNamelist(StdI);
 
 #elif defined(_UHF)
-  if (strcmp(StdI->calcmode, "uhfk") != 0) {  /* UHF */
+  PrintLocSpin(StdI);
+  PrintTrans(StdI);
+  PrintInteractions(StdI);
+  CheckModPara(StdI);
+  PrintModPara(StdI);
 
-    PrintLocSpin(StdI);
+  CheckOutputMode(StdI);
+  Print1Green(StdI);
+
+  PrintNamelist(StdI);
+
+#elif defined(_HWAVE)
+  if (strcmp(StdI->calcmode, "uhfk") == 0
+      || strcmp(StdI->calcmode, "rpa") == 0
+  {
+    /* UHFk or RPA mode */
+    ExportGeometry(StdI);
+    ExportInteraction(StdI);
+
+  } else {
+    /* otherwise (UHFr) */
+
+    /* PrintLocSpin(StdI); */
     PrintTrans(StdI);
     PrintInteractions(StdI);
     CheckModPara(StdI);
-    PrintModPara(StdI);
+    /* PrintModPara(StdI); */
 
     CheckOutputMode(StdI);
     Print1Green(StdI);
 
-    PrintNamelist(StdI);
-
-  } else {  /* UHFk */
-
-    ExportGeometry(StdI);
-    ExportInteraction(StdI);
+    /* PrintNamelist(StdI); */
 
   }
 #endif

--- a/src/StdFace_vals.h
+++ b/src/StdFace_vals.h
@@ -390,6 +390,22 @@ struct StdIntList {
     int NCellsub;/**<@brief Number of cells in a sublattice*/
     int boxsub[3][3];/**<@brief Sublattice*/
     int rboxsub[3][3];/**<@brief Sublattice*/
+#elif defined(_HWAVE)
+    int RndSeed;/**<@brief */
+    double mix; /**<@brief linear mixing ratio for update*/
+    int eps; /**<@brief convergence threshold for Green's functions */
+    int eps_slater;/**<@brief convergence threshold for Slater's functions */
+    int Iteration_max;/**<@brief max number for iterations*/
+    int NMPTrans;/**<@brief Number of translation symmetry*/
+    /*
+     Sub-lattice
+    */
+    int Lsub;/**<@brief Sublattice*/
+    int Wsub;/**<@brief Sublattice*/
+    int Hsub;/**<@brief Sublattice*/
+    int NCellsub;/**<@brief Number of cells in a sublattice*/
+    int boxsub[3][3];/**<@brief Sublattice*/
+    int rboxsub[3][3];/**<@brief Sublattice*/
 
   char calcmode[256];/**<@brief Calculation Mode: UHF, UHFk */
   char fileprefix[256];/**<@brief Prefix of output filenames */

--- a/src/StdFace_vals.h
+++ b/src/StdFace_vals.h
@@ -410,6 +410,7 @@ struct StdIntList {
   char calcmode[256];/**<@brief Calculation Mode: UHF, UHFk */
   char fileprefix[256];/**<@brief Prefix of output filenames */
   int export_all;/**<@brief output zero elements in UHFk mode */
+  int lattice_gp;/**<@brief create lattice.gp */
 #endif
 
 };

--- a/src/TriangularLattice.c
+++ b/src/TriangularLattice.c
@@ -34,13 +34,16 @@ void StdFace_Triangular(struct StdIntList *StdI)
 {
   int isite, jsite, kCell, ntransMax, nintrMax;
   int iL, iW;
-  FILE *fp;
+  FILE *fp = NULL;
   double complex Cphase;
   double dR[3];
 
   /**@brief
   (1) Compute the shape of the super-cell and sites in the super-cell
   */
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1)
+#endif
   fp = fopen("lattice.gp", "w");
   /**/
   StdI->NsiteUC = 1;
@@ -322,8 +325,14 @@ void StdFace_Triangular(struct StdIntList *StdI)
     }
   }/*for (kCell = 0; kCell < StdI->NCell; kCell++)*/
 
+#ifdef _HWAVE
+  if (StdI->lattice_gp == 1) {
+#endif
   fprintf(fp, "plot \'-\' w d lc 7\n0.0 0.0\nend\npause -1\n");
   fclose(fp);
+#ifdef _HWAVE
+  }
+#endif
   StdFace_PrintGeometry(StdI);
 }
 

--- a/src/export_wannier90.c
+++ b/src/export_wannier90.c
@@ -6,7 +6,7 @@
 #include "StdFace_vals.h"
 #include "StdFace_ModelUtil.h"
 
-#if defined(_UHF)
+#if defined(_HWAVE)
 
 // #undef NDEBUG
 
@@ -866,4 +866,4 @@ void ExportInteraction(struct StdIntList *StdI)
   return;
 }
 
-#endif /* defined(_UHF) */
+#endif /* defined(_HWAVE) */

--- a/src/export_wannier90.h
+++ b/src/export_wannier90.h
@@ -3,7 +3,7 @@
 
 //#include "StdFace_vals.h"
 
-#if defined(_UHF)
+#if defined(_HWAVE)
 
 void ExportGeometry(struct StdIntList *StdI);
 void ExportInteraction(struct StdIntList *StdI);


### PR DESCRIPTION
A compile target is introduced for H-wave calculation.
usage:
  cmake -DHWAVE=ON .
it yields hwave_dry.out for an executable.