### PR TITLE
In standard mode, NMPTrans (modpara) is always -1 and

### DIFF
--- a/src/StdFace_ModelUtil.c
+++ b/src/StdFace_ModelUtil.c
@@ -1451,12 +1451,7 @@ void StdFace_Proj(struct StdIntList *StdI)
     for (jsite = 0; jsite < StdI->nsite; jsite++) {
       if (Anti[iSym][jsite] % 2 == 0) Anti[iSym][jsite] = 1;
       else Anti[iSym][jsite] = -1;
-      if (StdI->AntiPeriod[0] == 1 || StdI->AntiPeriod[1] == 1 || StdI->AntiPeriod[2] == 1) {
-        fprintf(fp, "%5d  %5d  %5d  %5d\n", iSym, jsite, Sym[iSym][jsite], Anti[iSym][jsite]);
-      }
-      else {
-        fprintf(fp, "%5d  %5d  %5d\n", iSym, jsite, Sym[iSym][jsite]);
-      }
+      fprintf(fp, "%5d  %5d  %5d  %5d\n", iSym, jsite, Sym[iSym][jsite], Anti[iSym][jsite]);
     }
   }
   fflush(fp);

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -1905,9 +1905,7 @@ static void CheckModPara(struct StdIntList *StdI)
     StdFace_NotUsed_i("NSPStot", StdI->NSPStot);
   }
  
-  if (StdI->AntiPeriod[0] == 1 || StdI->AntiPeriod[1] == 1 || StdI->AntiPeriod[2] == 1)
-    StdFace_PrintVal_i("NMPTrans", &StdI->NMPTrans, -1);
-  else StdFace_PrintVal_i("NMPTrans", &StdI->NMPTrans, 1);
+  StdFace_PrintVal_i("NMPTrans", &StdI->NMPTrans, -1);
 
   StdFace_PrintVal_i("NSROptItrStep", &StdI->NSROptItrStep, 1000);
   


### PR DESCRIPTION
orbitalidxpara and qptransidx have extra column.