### PR TITLE
Fix cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,47 +1,17 @@
-cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
-project(StdFace NONE)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(StdFace C)
 
-message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
-enable_language(C)
+option(URF "Build urf_dri.out" ON)
+MESSAGE(STATUS "Build urf_dri.out - ${URF}")
 
-if(UHF)
-add_definitions(-D_UHF)
-endif(UHF)
+option(MVMC "Build mvmc_dri.out" ON)
+MESSAGE(STATUS "Build mvmc_dri.out - ${MVMC}")
 
-if(MVMC)
-add_definitions(-D_mVMC)
-endif(MVMC)
+option(HPHI "Build hphi_dri.out" ON)
+MESSAGE(STATUS "Build hphi_dri.out - ${HPHI}")
 
-if(HPHI)
-add_definitions(-D_HPhi)
-endif(HPHI)
+option(HWAVE "Build hwave_dri.out" ON)
+MESSAGE(STATUS "Build hwave_dri.out - ${HWAVE}")
 
-if(HWAVE)
-add_definitions(-D_HWAVE)
-endif(HWAVE)
-
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-set(CMAKE_MACOSX_RPATH 1)
-
-if("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
-else()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}")
-endif()
-
-find_package(LAPACK)
-if(USE_SCALAPACK MATCHES OFF)
-  if(LAPACK_FOUND)
-    add_definitions(-D_lapack)
-  endif(LAPACK_FOUND)
-endif()
 add_subdirectory(src)
-
-# Build and enable tests
-# testing setup
-# enable_testing() must be called in the top-level CMakeLists.txt before any add_subdirectory() is called.
-option(Testing "Enable testing" OFF)
+install(DIRECTORY samples DESTINATION share/stdface)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,17 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(StdFace C)
 
-option(URF "Build urf_dri.out" ON)
-MESSAGE(STATUS "Build urf_dri.out - ${URF}")
+option(UHF "Build uhf_dry.out" ON)
+MESSAGE(STATUS "Build uhf_dry.out - ${UHF}")
 
-option(MVMC "Build mvmc_dri.out" ON)
-MESSAGE(STATUS "Build mvmc_dri.out - ${MVMC}")
+option(MVMC "Build mvmc_dry.out" ON)
+MESSAGE(STATUS "Build mvmc_dry.out - ${MVMC}")
 
-option(HPHI "Build hphi_dri.out" ON)
-MESSAGE(STATUS "Build hphi_dri.out - ${HPHI}")
+option(HPHI "Build hphi_dry.out" ON)
+MESSAGE(STATUS "Build hphi_dry.out - ${HPHI}")
 
-option(HWAVE "Build hwave_dri.out" ON)
-MESSAGE(STATUS "Build hwave_dri.out - ${HWAVE}")
+option(HWAVE "Build hwave_dry.out" ON)
+MESSAGE(STATUS "Build hwave_dry.out - ${HWAVE}")
 
 add_subdirectory(src)
 install(DIRECTORY samples DESTINATION share/stdface)

--- a/README.md
+++ b/README.md
@@ -26,16 +26,15 @@ You can download StdFace from a [release note](https://github.com/issp-center-de
 ## Install StdFace
 
 ``` bash
-$ mkdir build && cd build
-$ cmake ../ -Dxxx="ON"
-$ make
-$ make install
+$ cmake -B build [options]
+$ cmake --build build
+$ cmake --install install
 ```
 
-If you define xxx as HPHI, hphi_dry.out is made.
-If you define xxx as MVMC, mvmc_dry.out is made.
-If you define xxx as UHF, uhf_dry.out is made.
-If you define xxx as HWAVE, hwave_dry.out is made.
+If you define -DUHF=OFF as [options], uhf_dry.out will not be made.
+If you define -DMVMC=OFF as [options], mvmc_dry.out will not be made.
+If you define -DHPHI=OFF as [options], hphi_dry.out will not be made.
+If you define -DHWAVE=OFF as [options], hawave_dry.out will not be made.
 
 ## Licence
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # include guard
-cmake_minimum_required(VERSION 2.8.0 )
+cmake_minimum_required(VERSION 3.0)
 
 if(${CMAKE_PROJECT_NAME} STREQUAL "Project")
   message(FATAL_ERROR "cmake should be executed not for 'src' subdirectory, but for the top directory of StdFace.")
@@ -7,36 +7,37 @@ endif(${CMAKE_PROJECT_NAME} STREQUAL "Project")
 
 include_directories(include)
 include_directories(common)
-set(SOURCES_StdFace
-        StdFacemain.c output.c cal_energy.c green.c makeham.c diag.c initial.c matrixlapack.c readdef.c common/setmemory.c
- )
-
 include_directories(sfmt)
 add_definitions(-DMEXP=19937)
 
-add_library(StdFace STATIC ChainLattice.c HoneycombLattice.c SquareLattice.c StdFace_main.c StdFace_ModelUtil.c TriangularLattice.c Ladder.c Kagome.c Orthorhombic.c Pyrochlore.c Wannier90.c FCOrtho.c setmemory.c export_wannier90.c)
+set(SOURCES_StdFace
+  ChainLattice.c HoneycombLattice.c SquareLattice.c StdFace_main.c StdFace_ModelUtil.c TriangularLattice.c Ladder.c Kagome.c Orthorhombic.c Pyrochlore.c Wannier90.c FCOrtho.c setmemory.c export_wannier90.c
+)
 
-if (UHF)
-   add_executable(uhf_dry.out dry.c)
-   target_link_libraries(uhf_dry.out StdFace m)
+if(URF)
+   add_executable(uhf_dry.out dry.c ${SOURCES_StdFace})
+   target_compile_definitions(uhf_dry.out PUBLIC _UHF)
+   target_link_libraries(uhf_dry.out PUBLIC m)
    install(TARGETS uhf_dry.out RUNTIME DESTINATION bin)
-endif(UHF)
+endif()
 
-if (MVMC)
-   add_executable(mvmc_dry.out dry.c)
-   target_link_libraries(mvmc_dry.out StdFace m)
+if(MVMC)
+   add_executable(mvmc_dry.out dry.c ${SOURCES_StdFace})
+   target_compile_definitions(mvmc_dry.out PUBLIC _MVMC)
+   target_link_libraries(mvmc_dry.out PUBLIC m)
    install(TARGETS mvmc_dry.out RUNTIME DESTINATION bin)
-endif(MVMC)
+endif()
 
-if (HPHI)
-   add_executable(hphi_dry.out dry.c)
-   target_link_libraries(hphi_dry.out StdFace m)
+if(HPHI)
+   add_executable(hphi_dry.out dry.c ${SOURCES_StdFace})
+   target_compile_definitions(hphi_dry.out PUBLIC _HPI)
+   target_link_libraries(hphi_dry.out PUBLIC m)
    install(TARGETS hphi_dry.out RUNTIME DESTINATION bin)
-endif(HPHI)
+endif()
 
 if (HWAVE)
-   add_executable(hwave_dry.out dry.c)
-   target_link_libraries(hwave_dry.out StdFace m)
+   add_executable(hwave_dry.out dry.c ${SOURCES_StdFace})
+   target_compile_definitions(hwave_dry.out PUBLIC _HWAVE)
+   target_link_libraries(hwave_dry.out PUBLIC m)
    install(TARGETS hwave_dry.out RUNTIME DESTINATION bin)
-endif(HWAVE)
-
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SOURCES_StdFace
   ChainLattice.c HoneycombLattice.c SquareLattice.c StdFace_main.c StdFace_ModelUtil.c TriangularLattice.c Ladder.c Kagome.c Orthorhombic.c Pyrochlore.c Wannier90.c FCOrtho.c setmemory.c export_wannier90.c
 )
 
-if(URF)
+if(UHF)
    add_executable(uhf_dry.out dry.c ${SOURCES_StdFace})
    target_compile_definitions(uhf_dry.out PUBLIC _UHF)
    target_link_libraries(uhf_dry.out PUBLIC m)


### PR DESCRIPTION
MateriApps LIVE! / Installer 向けの修正

- Build and install all xxx_dri.out by default
- Stop building library
- Install samples under ${PREFIX}/share/stdface

特にターゲット毎にマクロの定義を変えた(同名の)ライブラリを作成するのはあまりに危険だと思います