### PR TITLE
update CI environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-14, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-13]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
GitHub Actions のhosted runner としてはubuntu-20.04 はもうサポートされてないので削除。
ubuntu-latest, macos-latest, macos-13 を動かす（macos-13はintel-mac）