### PR TITLE
refactor(test): extract common test logic into shared check_case.sh

### DIFF
--- a/test/common/check_case.sh
+++ b/test/common/check_case.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Common CTest helper for StdFace:
+# - Copy case directory into working directory
+# - Run dry-run generator
+# - Compare outputs against ref/ using diff or almost_diff.py
+#
+# Usage:
+#   check_case.sh <test_item> <base_dir> <input_file> <default_cmd>
+#
+# Override command:
+#   DRY_CMD="python3 -m stdface.hphi_dry" ctest -V -R <testname>
+
+set -eu
+
+test_item=${1:?}
+base_dir=${2:?}
+input_file=${3:?}
+default_cmd=${4:?}
+
+# Allow caller override (may include args)
+DRY_CMD="${DRY_CMD:-$default_cmd}"
+
+almost_diff_py="${base_dir}/../almost_diff.py"
+
+# Avoid collisions across repeated runs
+if [ -d "${test_item}.bak" ]; then
+    rm -rf "${test_item}.bak"
+fi
+if [ -d "${test_item}" ]; then
+    mv "${test_item}" "${test_item}.bak"
+fi
+
+# Copy case directory into working directory (CTest sets WORKING_DIRECTORY)
+cp -rp "${base_dir}/${test_item}" .
+
+cd "${test_item}"
+
+# Run generator (log to run.log to match legacy behavior)
+sh -c "$DRY_CMD \"$input_file\"" > run.log 2>&1
+
+# Compare all files listed under ref/
+# Keep legacy semantics (ls-based list)
+file_list="$(cd ref && ls)"
+
+err=""
+
+for f in ${file_list}; do
+    {
+        echo "testing ${f}..."
+        if diff "ref/$f" "$f" \
+          || python3 "$almost_diff_py" "ref/$f" "$f"; then
+            echo "ok"
+        else
+            echo "$f: reference and result differ"
+            err="${err} ${f}"
+        fi
+    } >> run.log 2>&1
+done
+
+if [ -n "${err}" ]; then
+    echo "error found in:${err}"
+    exit 1
+fi
+
+exit 0

--- a/test/hphi/check.sh
+++ b/test/hphi/check.sh
@@ -1,41 +1,6 @@
 #!/bin/sh
-
-test_item=$1
-base_dir=$2
-
-DRY_BIN=../../../src/hphi_dry.out
-#DRY_BIN="HPhi -sdry"
-
-almost_diff="python3 ${base_dir}/../almost_diff.py"
-
-if [ -d ${test_item} ]; then
-    mv ${test_item} ${test_item}.bak
-fi
-
-cp -rp ${base_dir}/${test_item} .
-
-cd ${test_item}
-
-${DRY_BIN} stan.in > run.log 2>&1
-
-file_list=`(cd ref && ls)`
-
-err=""
-
-for f in ${file_list}
-do
-    echo "testing ${f}..."
-    if diff ref/$f $f || $almost_diff ref/$f $f ; then
-	echo "ok"
-    else
-	echo "$f: reference and result differ"
-	err="$err $f"
-    fi
-done >> run.log 2>&1
-
-if [ -n "$err" ]; then
-    echo "error found in:$err"
-    exit 1
-fi
-
-exit 0
+set -eu
+test_item=${1:?}
+base_dir=${2:?}
+exec "${base_dir}/../common/check_case.sh" \
+  "$test_item" "$base_dir" "stan.in" "../../../src/hphi_dry.out"

--- a/test/hwave/check.sh
+++ b/test/hwave/check.sh
@@ -1,40 +1,6 @@
 #!/bin/sh
-
-test_item=$1
-base_dir=$2
-
-DRY_BIN=../../../src/hwave_dry.out
-
-almost_diff="python3 ${base_dir}/../almost_diff.py"
-
-if [ -d ${test_item} ]; then
-    mv ${test_item} ${test_item}.bak
-fi
-
-cp -rp ${base_dir}/${test_item} .
-
-cd ${test_item}
-
-${DRY_BIN} stan.in > run.log 2>&1
-
-file_list=`(cd ref && ls)`
-
-err=""
-
-for f in ${file_list}
-do
-    echo "testing ${f}..."
-    if diff ref/$f $f || $almost_diff ref/$f $f ; then
-	echo "ok"
-    else
-	echo "$f: reference and result differ"
-	err="$err $f"
-    fi
-done >> run.log 2>&1
-
-if [ -n "$err" ]; then
-    echo "error found in:$err"
-    exit 1
-fi
-
-exit 0
+set -eu
+test_item=${1:?}
+base_dir=${2:?}
+exec "${base_dir}/../common/check_case.sh" \
+  "$test_item" "$base_dir" "stan.in" "../../../src/hwave_dry.out"

--- a/test/mvmc/check.sh
+++ b/test/mvmc/check.sh
@@ -1,40 +1,6 @@
 #!/bin/sh
-
-test_item=$1
-base_dir=$2
-
-DRY_BIN=../../../src/mvmc_dry.out
-
-almost_diff="python3 ${base_dir}/../almost_diff.py"
-
-if [ -d ${test_item} ]; then
-    mv ${test_item} ${test_item}.bak
-fi
-
-cp -rp ${base_dir}/${test_item} .
-
-cd ${test_item}
-
-${DRY_BIN} StdFace.def > run.log 2>&1
-
-file_list=`(cd ref && ls)`
-
-err=""
-
-for f in ${file_list}
-do
-    echo "testing ${f}..."
-    if diff ref/$f $f || $almost_diff ref/$f $f ; then
-	echo "ok"
-    else
-	echo "$f: reference and result differ"
-	err="$err $f"
-    fi
-done >> run.log 2>&1
-
-if [ -n "$err" ]; then
-    echo "error found in:$err"
-    exit 1
-fi
-
-exit 0
+set -eu
+test_item=${1:?}
+base_dir=${2:?}
+exec "${base_dir}/../common/check_case.sh" \
+  "$test_item" "$base_dir" "StdFace.def" "../../../src/mvmc_dry.out"

--- a/test/uhf/CMakeLists.txt
+++ b/test/uhf/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_test(
   NAME HubbardSquare
-  COMMAND ${CMAKE_SOURCE_DIR}/test/uhf/check.sh HubbardSquare ${CMAKE_SOURCE_DIR}/test/hwave
+  COMMAND ${CMAKE_SOURCE_DIR}/test/uhf/check.sh HubbardSquare ${CMAKE_SOURCE_DIR}/test/uhf
 )
 add_test(
   NAME HubbardTriangle
-  COMMAND ${CMAKE_SOURCE_DIR}/test/uhf/check.sh HubbardTriangle ${CMAKE_SOURCE_DIR}/test/hwave
+  COMMAND ${CMAKE_SOURCE_DIR}/test/uhf/check.sh HubbardTriangle ${CMAKE_SOURCE_DIR}/test/uhf
 )

--- a/test/uhf/check.sh
+++ b/test/uhf/check.sh
@@ -1,40 +1,6 @@
 #!/bin/sh
-
-test_item=$1
-base_dir=$2
-
-DRY_BIN=../../../src/uhf_dry.out
-
-almost_diff="python3 ${base_dir}/../almost_diff.py"
-
-if [ -d ${test_item} ]; then
-    mv ${test_item} ${test_item}.bak
-fi
-
-cp -rp ${base_dir}/${test_item} .
-
-cd ${test_item}
-
-${DRY_BIN} stan.in > run.log 2>&1
-
-file_list=`(cd ref && ls)`
-
-err=""
-
-for f in ${file_list}
-do
-    echo "testing ${f}..."
-    if diff ref/$f $f || $almost_diff ref/$f $f ; then
-	echo "ok"
-    else
-	echo "$f: reference and result differ"
-	err="$err $f"
-    fi
-done >> run.log 2>&1
-
-if [ -n "$err" ]; then
-    echo "error found in:$err"
-    exit 1
-fi
-
-exit 0
+set -eu
+test_item=${1:?}
+base_dir=${2:?}
+exec "${base_dir}/../common/check_case.sh" \
+  "$test_item" "$base_dir" "stan.in" "../../../src/uhf_dry.out"


### PR DESCRIPTION
- Create test/common/check_case.sh with reusable test case runner
- Simplify check.sh in hphi, hwave, mvmc, uhf to use common script
- Add DRY_CMD environment variable for command override
- Fix uhf/CMakeLists.txt path (hwave -> uhf)