### PR TITLE
Keep mVMC NSROptItrSmp default positive

### DIFF
--- a/python/stdface/writer/common_writer.py
+++ b/python/stdface/writer/common_writer.py
@@ -951,8 +951,9 @@ def _check_mod_para_mvmc(StdI: StdIntList) -> None:
 
     if StdI.NVMCCalMode == 1:
         not_used_i("NSROptItrSmp", StdI.NSROptItrSmp)
+    sropt_itr_smp_default = max(1, StdI.NSROptItrStep // 10)
     StdI.NSROptItrSmp = print_val_i(
-        "NSROptItrSmp", StdI.NSROptItrSmp, StdI.NSROptItrStep // 10
+        "NSROptItrSmp", StdI.NSROptItrSmp, sropt_itr_smp_default
     )
 
     StdI.NVMCWarmUp = print_val_i("NVMCWarmUp", StdI.NVMCWarmUp, 10)

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -1972,6 +1972,8 @@ static void CheckModPara(struct StdIntList *StdI)
   StdFace_PrintVal_d("OmegaOrg", &StdI->OmegaOrg, 0.0);
   StdFace_PrintVal_d("OmegaIm", &StdI->OmegaIm, 0.01* (int)StdI->LargeValue);
 #elif defined(_mVMC)
+  int nSROptItrSmpDefault;
+
   if (strcmp(StdI->CParaFileHead, "****") == 0) {
     strcpy(StdI->CParaFileHead, "zqp\0");
     fprintf(stdout, "    CParaFileHead = %-12s######  DEFAULT VALUE IS USED  ######\n", StdI->CParaFileHead);
@@ -1999,7 +2001,9 @@ static void CheckModPara(struct StdIntList *StdI)
   StdFace_PrintVal_i("NSROptItrStep", &StdI->NSROptItrStep, 1000);
   
   if (StdI->NVMCCalMode == 1) StdFace_NotUsed_i("NSROptItrSmp", StdI->NSROptItrSmp);
-  /*else*/ StdFace_PrintVal_i("NSROptItrSmp", &StdI->NSROptItrSmp, StdI->NSROptItrStep/10);
+  nSROptItrSmpDefault = StdI->NSROptItrStep/10;
+  if (nSROptItrSmpDefault < 1) nSROptItrSmpDefault = 1;
+  /*else*/ StdFace_PrintVal_i("NSROptItrSmp", &StdI->NSROptItrSmp, nSROptItrSmpDefault);
 
   StdFace_PrintVal_i("NVMCWarmUp", &StdI->NVMCWarmUp, 10);
   StdFace_PrintVal_i("NVMCInterval", &StdI->NVMCInterval, 1);

--- a/test/mvmc/CMakeLists.txt
+++ b/test/mvmc/CMakeLists.txt
@@ -15,6 +15,10 @@ add_test(
   COMMAND ${CMAKE_SOURCE_DIR}/test/mvmc/check.sh HubbardChain ${CMAKE_SOURCE_DIR}/test/mvmc
 )
 add_test(
+  NAME HubbardChainShortSROpt
+  COMMAND ${CMAKE_SOURCE_DIR}/test/mvmc/check_short_sropt.sh HubbardChainShortSROpt ${CMAKE_SOURCE_DIR}/test/mvmc "../../../src/mvmc_dry.out"
+)
+add_test(
   NAME HubbardChainLanczos
   COMMAND ${CMAKE_SOURCE_DIR}/test/mvmc/check.sh HubbardChainLanczos ${CMAKE_SOURCE_DIR}/test/mvmc
 )

--- a/test/mvmc/HubbardChainShortSROpt/StdFace.def
+++ b/test/mvmc/HubbardChainShortSROpt/StdFace.def
@@ -1,0 +1,14 @@
+L             = 6
+Lsub          = 2
+model         = "Hubbard"
+lattice       = "chain"
+U             = 4.0
+t             = 1.0
+Ncond         = 6
+NSROptItrStep = 2
+NVMCSample    = 100
+2Sz           = 0
+DSROptRedCut  = 1e-8
+DSROptStaDel  = 1e-2
+DSROptStepDt  = 3e-3
+RndSeed = 1

--- a/test/mvmc/check_short_sropt.sh
+++ b/test/mvmc/check_short_sropt.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+test_item=${1:?}
+base_dir=${2:?}
+dry_cmd=${3:?}
+
+if [ -d "${test_item}.bak" ]; then
+    rm -rf "${test_item}.bak"
+fi
+if [ -d "${test_item}" ]; then
+    mv "${test_item}" "${test_item}.bak"
+fi
+
+cp -rp "${base_dir}/${test_item}" .
+cd "${test_item}"
+
+"${dry_cmd}" StdFace.def > run.log 2>&1
+
+if ! grep -q "^NSROptItrStep  2$" modpara.def; then
+    echo "NSROptItrStep was not set to 2"
+    exit 1
+fi
+
+if ! grep -q "^NSROptItrSmp   1$" modpara.def; then
+    echo "NSROptItrSmp default was not clamped to 1"
+    exit 1
+fi

--- a/test/unit/test_common_writer.py
+++ b/test/unit/test_common_writer.py
@@ -1077,6 +1077,27 @@ class TestSolverDefaultsDispatch:
         _check_mod_para_mvmc(StdI)
         assert StdI.NVMCCalMode == 0
 
+    def test_mvmc_keeps_sropt_sample_default_positive(self):
+        StdI = _make_stdi_base(solver="mVMC", model="hubbard")
+        StdI.NVMCCalMode = NaN_i
+        StdI.NLanczosMode = NaN_i
+        StdI.NDataIdxStart = NaN_i
+        StdI.NDataQtySmp = NaN_i
+        StdI.NSPGaussLeg = NaN_i
+        StdI.NSPStot = NaN_i
+        StdI.NMPTrans = NaN_i
+        StdI.NSROptItrStep = 2
+        StdI.NSROptItrSmp = NaN_i
+        StdI.NVMCWarmUp = NaN_i
+        StdI.NVMCInterval = NaN_i
+        StdI.NVMCSample = NaN_i
+        StdI.RndSeed = NaN_i
+        StdI.NSplitSize = NaN_i
+        StdI.NStore = NaN_i
+        StdI.NSRCG = NaN_i
+        _check_mod_para_mvmc(StdI)
+        assert StdI.NSROptItrSmp == 1
+
     def test_mvmc_sets_rndseed(self):
         StdI = _make_stdi_base(solver="mVMC", model="hubbard")
         StdI.NVMCCalMode = NaN_i


### PR DESCRIPTION
## Summary

- Clamp the mVMC standard-mode default `NSROptItrSmp` to at least `1`
  in the C StdFace implementation.
- Apply the same default handling to the Python writer on `develop`.
- Add regression coverage for `NSROptItrStep = 2`, where integer division
  previously produced `NSROptItrSmp = 0`.

## Motivation

The mVMC standard-mode default for `NSROptItrSmp` is derived from
`NSROptItrStep / 10`. For short optimization runs such as
`NSROptItrStep = 2`, integer division made the generated `modpara.def`
contain:

```text
NSROptItrSmp   0
```

`NSROptItrSmp` is documented as a positive integer, and a zero averaging
window can lead to invalid optimized-parameter output. This PR keeps the
default positive while preserving the existing default for normal runs
where `NSROptItrStep >= 10`.

## Tests

```bash
cmake -S . -B <build-dir> -DMVMC=ON -DTestStdFace=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
cmake --build <build-dir> -j2
ctest --test-dir <build-dir> -R HubbardChainShortSROpt --output-on-failure
ctest --test-dir <build-dir> --output-on-failure
PYTHONPATH=python pytest test/unit/test_common_writer.py -q
PYTHONPATH=python pytest test/unit -q
```
