### PR TITLE
Add HPhi spinless fermion chain standard mode

### DIFF
--- a/src/ChainLattice.c
+++ b/src/ChainLattice.c
@@ -28,6 +28,17 @@
 #include <complex.h>
 #include <string.h>
 
+static void StdFace_SpinlessHopping(
+  struct StdIntList *StdI,
+  double complex trans0,
+  int isite,
+  int jsite
+)
+{
+  StdFace_trans(StdI, trans0, jsite, 0, isite, 0);
+  StdFace_trans(StdI, conj(trans0), isite, 0, jsite, 0);
+}
+
 /**
 @brief Setup a Hamiltonian for the Hubbard model on a Chain lattice
 @author Mitsuaki Kawamura (The University of Tokyo)
@@ -66,8 +77,11 @@ void StdFace_Chain(
   FILE *fp = NULL;
   int isite, jsite, ntransMax, nintrMax;
   int iL;
+  int is_spinless;
   double complex Cphase;
   double dR[3];
+
+  is_spinless = (strcmp(StdI->model, "spinlessfermion") == 0);
 
   /**@brief
   (1) Compute the shape of the super-cell and sites in the super-cell
@@ -116,11 +130,11 @@ void StdFace_Chain(
   StdFace_NotUsed_d("V1'", StdI->V1p);
   StdFace_NotUsed_d("V2'", StdI->V2p);
   StdFace_NotUsed_d("K", StdI->K);
-  StdFace_PrintVal_d("h", &StdI->h, 0.0);
-  StdFace_PrintVal_d("Gamma", &StdI->Gamma, 0.0);
-  StdFace_PrintVal_d("Gamma_y", &StdI->Gamma_y, 0.0);
   /**/
   if (strcmp(StdI->model, "spin") == 0 ) {
+    StdFace_PrintVal_d("h", &StdI->h, 0.0);
+    StdFace_PrintVal_d("Gamma", &StdI->Gamma, 0.0);
+    StdFace_PrintVal_d("Gamma_y", &StdI->Gamma_y, 0.0);
     StdFace_PrintVal_i("2S", &StdI->S2, 1);
     StdFace_PrintVal_d("D", &StdI->D[2][2], 0.0);
     StdFace_InputSpinNN(StdI->J, StdI->JAll, StdI->J0, StdI->J0All, "J0");
@@ -136,7 +150,33 @@ void StdFace_Chain(
     StdFace_NotUsed_d("V0", StdI->V0);
     StdFace_NotUsed_d("V'", StdI->Vp);
   }/*if (strcmp(StdI->model, "spin") == 0 )*/
+  else if (is_spinless) {
+    StdFace_NotUsed_d("h", StdI->h);
+    StdFace_NotUsed_d("Gamma", StdI->Gamma);
+    StdFace_NotUsed_d("Gamma_y", StdI->Gamma_y);
+    StdFace_InputHopp(StdI->t, &StdI->t0, "t0");
+    StdFace_InputHopp(StdI->tp, &StdI->t0p, "t0'");
+    StdFace_InputHopp(StdI->tpp, &StdI->t0pp, "t0''");
+
+    StdFace_NotUsed_d("mu", StdI->mu);
+    StdFace_NotUsed_d("U", StdI->U);
+    StdFace_NotUsed_d("V", StdI->V);
+    StdFace_NotUsed_d("V0", StdI->V0);
+    StdFace_NotUsed_d("V'", StdI->Vp);
+    StdFace_NotUsed_d("V0'", StdI->V0p);
+    StdFace_NotUsed_d("V''", StdI->Vpp);
+    StdFace_NotUsed_d("V0''", StdI->V0pp);
+    StdFace_NotUsed_J("J", StdI->JAll, StdI->J);
+    StdFace_NotUsed_J("J0", StdI->J0All, StdI->J0);
+    StdFace_NotUsed_J("J0'", StdI->J0pAll, StdI->J0p);
+    StdFace_NotUsed_J("J0''", StdI->J0ppAll, StdI->J0pp);
+    StdFace_NotUsed_d("D", StdI->D[2][2]);
+    StdFace_NotUsed_i("2S", StdI->S2);
+  }/*else if (is_spinless)*/
   else {
+    StdFace_PrintVal_d("h", &StdI->h, 0.0);
+    StdFace_PrintVal_d("Gamma", &StdI->Gamma, 0.0);
+    StdFace_PrintVal_d("Gamma_y", &StdI->Gamma_y, 0.0);
     StdFace_PrintVal_d("mu", &StdI->mu, 0.0);
     StdFace_PrintVal_d("U", &StdI->U, 0.0);
     StdFace_InputHopp(StdI->t, &StdI->t0, "t0");
@@ -171,7 +211,7 @@ void StdFace_Chain(
   /**/
   if (strcmp(StdI->model, "spin") == 0 )
     for (isite = 0; isite < StdI->nsite; isite++)StdI->locspinflag[isite] = StdI->S2;
-  else if (strcmp(StdI->model, "hubbard") == 0 ) 
+  else if (strcmp(StdI->model, "hubbard") == 0 || is_spinless)
     for (isite = 0; isite < StdI->nsite; isite++)StdI->locspinflag[isite] = 0;
   else if (strcmp(StdI->model, "kondo") == 0 ) 
     for (isite = 0; isite < StdI->nsite / 2; isite++) {
@@ -185,6 +225,10 @@ void StdFace_Chain(
     ntransMax = StdI->L * (StdI->S2 + 1/*h*/ + 2 * StdI->S2/*Gamma*/);
     nintrMax = StdI->L * (StdI->NsiteUC/*D*/ + 1/*J*/ + 1/*J'*/ + 1/*J''*/)
       * (3 * StdI->S2 + 1) * (3 * StdI->S2 + 1);
+  }
+  else if (is_spinless) {
+    ntransMax = StdI->L * (2/*t*/ + 2/*t'*/ + 2/*t''*/);
+    nintrMax = StdI->L;
   }
   else {
     ntransMax = StdI->L * 2/*spin*/ * (2 * StdI->NsiteUC/*mu+h+Gamma*/ + 2/*t*/ + 2/*t'*/ + 2/*t''*/);
@@ -212,7 +256,9 @@ void StdFace_Chain(
       StdFace_GeneralJ(StdI, StdI->D, StdI->S2, StdI->S2, isite, isite);
     }/*if (strcmp(StdI->model, "spin") == 0 )*/
     else {
-      StdFace_HubbardLocal(StdI, StdI->mu, -StdI->h, -StdI->Gamma, -StdI->Gamma_y, StdI->U, isite);
+      if (!is_spinless) {
+        StdFace_HubbardLocal(StdI, StdI->mu, -StdI->h, -StdI->Gamma, -StdI->Gamma_y, StdI->U, isite);
+      }
       if (strcmp(StdI->model, "kondo") == 0 ) {
         jsite = iL;
         StdFace_GeneralJ(StdI, StdI->J, 1, StdI->S2, isite, jsite);
@@ -227,6 +273,9 @@ void StdFace_Chain(
     if (strcmp(StdI->model, "spin") == 0 ) {
       StdFace_GeneralJ(StdI, StdI->J0, StdI->S2, StdI->S2, isite, jsite);
     }
+    else if (is_spinless) {
+      StdFace_SpinlessHopping(StdI, Cphase * StdI->t0, isite, jsite);
+    }
     else {
       StdFace_Hopping(StdI, Cphase * StdI->t0, isite, jsite, dR);
       StdFace_Coulomb(StdI, StdI->V0, isite, jsite);
@@ -239,6 +288,9 @@ void StdFace_Chain(
     if (strcmp(StdI->model, "spin") == 0 ) {
       StdFace_GeneralJ(StdI, StdI->J0p, StdI->S2, StdI->S2, isite, jsite);
     }
+    else if (is_spinless) {
+      StdFace_SpinlessHopping(StdI, Cphase * StdI->t0p, isite, jsite);
+    }
     else {
       StdFace_Hopping(StdI, Cphase * StdI->t0p, isite, jsite, dR);
       StdFace_Coulomb(StdI, StdI->V0p, isite, jsite);
@@ -250,6 +302,9 @@ void StdFace_Chain(
     /**/
     if (strcmp(StdI->model, "spin") == 0) {
       StdFace_GeneralJ(StdI, StdI->J0pp, StdI->S2, StdI->S2, isite, jsite);
+    }
+    else if (is_spinless) {
+      StdFace_SpinlessHopping(StdI, Cphase * StdI->t0pp, isite, jsite);
     }
     else {
       StdFace_Hopping(StdI, Cphase * StdI->t0pp, isite, jsite, dR);

--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -130,6 +130,10 @@ static void PrintCalcMod(struct StdIntList *StdI)
     if (StdI->lGC == 0)iCalcModel = 2;
     else iCalcModel = 5;
   }/*if (strcmp(StdI->model, "kondo") == 0)*/
+  else if (strcmp(StdI->model, "spinlessfermion") == 0) {
+    if (StdI->lGC == 0)iCalcModel = 7;
+    else iCalcModel = 8;
+  }/*if (strcmp(StdI->model, "spinlessfermion") == 0)*/
   /*
   Restart
   */
@@ -1467,16 +1471,20 @@ static void CheckMomentumSymmetry(struct StdIntList *StdI)
 {
   double eps = 1.0e-12;
   int idim;
+  int is_spin;
+  int is_spinless;
   if (!StdFace_UsesMomentumSymmetry(StdI)) return;
+  is_spin = (strcmp(StdI->model, "spin") == 0);
+  is_spinless = (strcmp(StdI->model, "spinlessfermion") == 0);
   if (!StdFace_IsChainLattice(StdI)) {
     fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only chain lattice.\n");
     StdFace_exit(-1);
   }
-  if (strcmp(StdI->model, "spin") != 0 || StdI->lGC != 0) {
-    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only canonical Spin model.\n");
+  if ((!is_spin && !is_spinless) || StdI->lGC != 0) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only canonical Spin or SpinlessFermion model.\n");
     StdFace_exit(-1);
   }
-  if (StdI->S2 != 1) {
+  if (is_spin && StdI->S2 != 1) {
     fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only Spin-1/2.\n");
     StdFace_exit(-1);
   }
@@ -1494,13 +1502,23 @@ static void CheckMomentumSymmetry(struct StdIntList *StdI)
       StdFace_exit(-1);
     }
   }
-  if (StdFace_HasNonZeroComplexTerms(StdI->trans, StdI->ntrans, eps) ||
-      StdFace_HasNonZeroComplexTerms(StdI->intr, StdI->nintr, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->Cinter, StdI->NCinter, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->Hund, StdI->NHund, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->PairLift, StdI->NPairLift, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->PairHopp, StdI->NPairHopp, eps)) {
+  if (is_spin &&
+      (StdFace_HasNonZeroComplexTerms(StdI->trans, StdI->ntrans, eps) ||
+       StdFace_HasNonZeroComplexTerms(StdI->intr, StdI->nintr, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->Cinter, StdI->NCinter, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->Hund, StdI->NHund, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->PairLift, StdI->NPairLift, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->PairHopp, StdI->NPairHopp, eps))) {
     fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only exchange-only Spin-1/2 chain with Jz = 0 and no field/general/pair terms.\n");
+    StdFace_exit(-1);
+  }
+  if (is_spinless &&
+      (StdFace_HasNonZeroComplexTerms(StdI->intr, StdI->nintr, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->Cinter, StdI->NCinter, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->Hund, StdI->NHund, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->PairLift, StdI->NPairLift, eps) ||
+       StdFace_HasNonZeroRealTerms(StdI->PairHopp, StdI->NPairHopp, eps))) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only hopping-only SpinlessFermion chain with no density/general/pair terms.\n");
     StdFace_exit(-1);
   }
 }
@@ -2179,6 +2197,17 @@ static void CheckModPara(struct StdIntList *StdI)
     else StdFace_NotUsed_i("2Sz", StdI->Sz2);
 #endif
   }/*else if (strcmp(StdI->model, "kondo") == 0)*/
+  else if (strcmp(StdI->model, "spinlessfermion") == 0) {
+#if defined(_HPhi)
+    if (StdI->lGC == 0) StdFace_RequiredVal_i("ncond", StdI->ncond);
+    else {
+      StdFace_NotUsed_i("nelec", StdI->ncond);
+    }
+    StdFace_NotUsed_i("2Sz", StdI->Sz2);
+#else
+    UnsupportedSystem(StdI->model, StdI->lattice);
+#endif
+  }/*else if (strcmp(StdI->model, "spinlessfermion") == 0)*/
 }/*static void CheckModPara*/
 /**
  * @brief Output .def files for specific interactions (Coulomb, Hund, Exchange, etc.)
@@ -3078,6 +3107,11 @@ void StdFace_main(
     strcpy(StdI->model, "kondo\0");
     StdI->lGC = 1;
   }
+#if defined(_HPhi)
+  else if (strcmp(StdI->model, "spinlessfermion") == 0
+    || strcmp(StdI->model, "spinless") == 0)
+    strcpy(StdI->model, "spinlessfermion\0");
+#endif
   else UnsupportedSystem(StdI->model, StdI->lattice);
 #if defined(_HPhi)
   /*
@@ -3094,6 +3128,11 @@ void StdFace_main(
   Compute vector potential and electrical field
   */
   if (strcmp(StdI->method, "timeevolution") == 0) VectorPotential(StdI);
+  if (strcmp(StdI->model, "spinlessfermion") == 0 &&
+      !StdFace_IsChainLattice(StdI)) {
+    fprintf(stdout, "\n ERROR ! SpinlessFermion Standard mode currently supports only chain lattice.\n");
+    StdFace_exit(-1);
+  }
 #endif
   /*>>
   Generate Hamiltonian definition files


### PR DESCRIPTION
## Summary
- Add HPhi Standard-mode support for canonical SpinlessFermion on chain lattices
- Generate spinless hopping-only transfer terms and map the model to CalcModel 7
- Allow MomentumIndex for SpinlessFermion chains while rejecting unsupported non-chain lattices and non-hopping term families

## Validation
- Built HPhi after the StdFace submodule update
- Ran the SpinlessFermion Standard-mode symmetry regression
- Ran the full symmetry-labeled regression set
- Ran whitespace checks for both HPhi and StdFace diffs

## Notes
- Density interactions remain out of scope and are intentionally rejected for this step
- HPhi-side tests and the submodule pointer update will be handled in the dependent HPhi PR