### PR TITLE
Add HPhi Hubbard momentum standard mode

### DIFF
--- a/src/StdFace_main.c
+++ b/src/StdFace_main.c
@@ -1463,6 +1463,91 @@ static int StdFace_HasNonZeroComplexTerms(double complex *terms, int nterms, dou
   return 0;
 }
 
+static int StdFace_HasNonZeroReal(double term, double eps)
+{
+  return isnan(term) == 0 && fabs(term) > eps;
+}
+
+static int StdFace_HasNonZeroComplex(double complex term, double eps)
+{
+  return isnan(creal(term)) == 0 && cabs(term) > eps;
+}
+
+static int StdFace_IsLanczosOrCGMethod(struct StdIntList *StdI)
+{
+  return strcmp(StdI->method, "****") == 0 ||
+         strcmp(StdI->method, "lanczos") == 0 ||
+         strcmp(StdI->method, "lanczosenergy") == 0 ||
+         strcmp(StdI->method, "cg") == 0;
+}
+
+static void CheckMomentumSpinSymmetry(struct StdIntList *StdI, double eps)
+{
+  if (StdI->lGC != 0) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only canonical Spin model.\n");
+    StdFace_exit(-1);
+  }
+  if (StdI->S2 != 1) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only Spin-1/2.\n");
+    StdFace_exit(-1);
+  }
+  if (!StdFace_IsLanczosOrCGMethod(StdI)) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only Lanczos and CG.\n");
+    StdFace_exit(-1);
+  }
+  if (StdFace_HasNonZeroComplexTerms(StdI->trans, StdI->ntrans, eps) ||
+      StdFace_HasNonZeroComplexTerms(StdI->intr, StdI->nintr, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->Cinter, StdI->NCinter, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->Hund, StdI->NHund, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->PairLift, StdI->NPairLift, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->PairHopp, StdI->NPairHopp, eps)) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only exchange-only Spin-1/2 chain with Jz = 0 and no field/general/pair terms.\n");
+    StdFace_exit(-1);
+  }
+}
+
+static void CheckMomentumHubbardSymmetry(struct StdIntList *StdI, double eps)
+{
+  if (StdI->lGC != 0) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only canonical Hubbard model.\n");
+    StdFace_exit(-1);
+  }
+  if (StdI->ncond == StdI->NaN_i || StdI->Sz2 == StdI->NaN_i) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex for Hubbard requires nelec and 2Sz.\n");
+    StdFace_exit(-1);
+  }
+  if (!StdFace_IsLanczosOrCGMethod(StdI)) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only Lanczos and CG.\n");
+    StdFace_exit(-1);
+  }
+  if (StdFace_HasNonZeroReal(StdI->mu, eps) ||
+      StdFace_HasNonZeroReal(StdI->h, eps) ||
+      StdFace_HasNonZeroReal(StdI->Gamma, eps) ||
+      StdFace_HasNonZeroReal(StdI->Gamma_y, eps)) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex for Hubbard does not support mu/h/Gamma/Gamma_y terms.\n");
+    StdFace_exit(-1);
+  }
+  if (StdFace_HasNonZeroComplex(StdI->t0p, eps) ||
+      StdFace_HasNonZeroComplex(StdI->t0pp, eps)) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex for Hubbard does not support next-neighbor hopping terms.\n");
+    StdFace_exit(-1);
+  }
+  if (StdFace_HasNonZeroReal(StdI->V0, eps) ||
+      StdFace_HasNonZeroReal(StdI->V0p, eps) ||
+      StdFace_HasNonZeroReal(StdI->V0pp, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->Cinter, StdI->NCinter, eps)) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex for Hubbard does not support V/CoulombInter terms.\n");
+    StdFace_exit(-1);
+  }
+  if (StdFace_HasNonZeroComplexTerms(StdI->intr, StdI->nintr, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->Hund, StdI->NHund, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->PairLift, StdI->NPairLift, eps) ||
+      StdFace_HasNonZeroRealTerms(StdI->PairHopp, StdI->NPairHopp, eps)) {
+    fprintf(stdout, "\n ERROR ! MomentumIndex for Hubbard supports only nearest-neighbor hopping and onsite U.\n");
+    StdFace_exit(-1);
+  }
+}
+
 static void CheckMomentumSymmetry(struct StdIntList *StdI)
 {
   double eps = 1.0e-12;
@@ -1470,14 +1555,6 @@ static void CheckMomentumSymmetry(struct StdIntList *StdI)
   if (!StdFace_UsesMomentumSymmetry(StdI)) return;
   if (!StdFace_IsChainLattice(StdI)) {
     fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only chain lattice.\n");
-    StdFace_exit(-1);
-  }
-  if (strcmp(StdI->model, "spin") != 0 || StdI->lGC != 0) {
-    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only canonical Spin model.\n");
-    StdFace_exit(-1);
-  }
-  if (StdI->S2 != 1) {
-    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only Spin-1/2.\n");
     StdFace_exit(-1);
   }
   if (StdI->L <= 0) {
@@ -1494,13 +1571,14 @@ static void CheckMomentumSymmetry(struct StdIntList *StdI)
       StdFace_exit(-1);
     }
   }
-  if (StdFace_HasNonZeroComplexTerms(StdI->trans, StdI->ntrans, eps) ||
-      StdFace_HasNonZeroComplexTerms(StdI->intr, StdI->nintr, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->Cinter, StdI->NCinter, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->Hund, StdI->NHund, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->PairLift, StdI->NPairLift, eps) ||
-      StdFace_HasNonZeroRealTerms(StdI->PairHopp, StdI->NPairHopp, eps)) {
-    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only exchange-only Spin-1/2 chain with Jz = 0 and no field/general/pair terms.\n");
+  if (strcmp(StdI->model, "spin") == 0) {
+    CheckMomentumSpinSymmetry(StdI, eps);
+  }
+  else if (strcmp(StdI->model, "hubbard") == 0) {
+    CheckMomentumHubbardSymmetry(StdI, eps);
+  }
+  else {
+    fprintf(stdout, "\n ERROR ! MomentumIndex currently supports only Spin and Hubbard models.\n");
     StdFace_exit(-1);
   }
 }


### PR DESCRIPTION
## Summary
- Allow HPhi Standard mode `MomentumIndex` for canonical one-dimensional Hubbard chains.
- Keep the existing Spin guard behavior and split the MomentumIndex validation into Spin and Hubbard model-specific helpers.
- Reject unsupported Hubbard Standard mode combinations, including GC, non-chain lattices, boundary phases, missing fixed `nelec`/`2Sz`, longer-range hopping, fields, offsite Coulomb terms, general interactions, pair terms, and unsupported solver methods.

## Supported HPhi scope
- `model = FermionHubbard` or `Hubbard`
- `lattice = chain`
- fixed `nelec` and `2Sz`
- Lanczos or CG
- nearest-neighbor hopping and onsite `U`

## Verification
Validated through the dependent HPhi CF4b branch:
- Standard generated `qptransidx.def` matches hand-written expert-mode TransSym for `L=4`, `nelec=2`, `2Sz=0`, `MomentumIndex=0`, `U=0.5`.
- The `MomentumIndex=0` sector matches the TransSym-free full-space reference.
- `MomentumIndex=1`, `U=0` gives the expected sector energy `-2.0` and the generated translation character for one-site translation is `(0, -1)`.
- Negative cases reject invalid MomentumIndex, boundary phase, missing `2Sz`, offsite Coulomb terms, non-chain lattices, and FullDiag.
- The generated expert input passes serial and MPI checks with 4 and 16 ranks.
